### PR TITLE
Add test image repo lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All of the SIG-Windows tests are included in the `e2e.test` binary. You need to 
 
 ```bash
 export KUBECONFIG=path/to/kubeconfig
-curl https://raw.githubusercontent.com/e2e-win/e2e-win-prow-deployment/master/repo-list -o repo_list
+curl https://raw.githubusercontent.com/windows-testing/master/images/image-repo-list-ws2019 -o repo_list
 export KUBE_TEST_REPO_LIST=$(pwd)/repo_list
 
 ./e2e.test --provider=local --ginkgo.noColor --ginkgo.focus="\[sig-windows\]" --node-os-distro="windows"

--- a/images/image-repo-list-ws1803
+++ b/images/image-repo-list-ws1803
@@ -1,0 +1,8 @@
+dockerLibraryRegistry: e2eteam
+e2eRegistry: e2eteam
+gcRegistry: e2eteam
+hazelcastRegistry: e2eteam
+PrivateRegistry: e2eteam
+sampleRegistry: e2eteam
+stormRegistry: e2eteam
+zookeeperRegistry: e2eteam

--- a/images/image-repo-list-ws2019
+++ b/images/image-repo-list-ws2019
@@ -1,0 +1,8 @@
+dockerLibraryRegistry: claudiubelu
+e2eRegistry: claudiubelu
+gcRegistry: claudiubelu
+hazelcastRegistry: claudiubelu
+PrivateRegistry: claudiubelu
+sampleRegistry: claudiubelu
+stormRegistry: claudiubelu
+zookeeperRegistry: claudiubelu


### PR DESCRIPTION
The lists are originally located in github.com/e2e-win/e2e-win-prow-deployment
Move the lists to the official sig-windows testing repository and update
the README.