### PR TITLE
Change Windows VM to use a 500 IOPs disk instead of 120

### DIFF
--- a/job-templates/kubernetes_release.json
+++ b/job-templates/kubernetes_release.json
@@ -21,7 +21,7 @@
         "name": "windowspool2",
         "count": 2,
         "vmSize": "Standard_D2s_v3",
-	"osDiskSizeGB": 128,
+        "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",
         "preProvisionExtension":

--- a/job-templates/kubernetes_release.json
+++ b/job-templates/kubernetes_release.json
@@ -20,7 +20,8 @@
       {
         "name": "windowspool2",
         "count": 2,
-        "vmSize": "Standard_D2_v3",
+        "vmSize": "Standard_D2s_v3",
+	"osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",
         "preProvisionExtension":


### PR DESCRIPTION
The current config used to test on Azure uses a `Standard_D2_v3` VM with standard storage. This change moves it to [Standard_D2s_v3](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-general) which allows SSD storage, and increases the disk size so it will get the [P10](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#premium-storage-disk-limits) disk for 500 IOPs.

The latest run [225](https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-win-1-13/225) took 41 minutes to deploy all the VMs, which includes pulling the Windows test images.

In my testing, the same deployment took 37 minutes. It may also decrease the time to run individual test cases since pods may start faster. I can't measure that as easily so I would check it after this merges and we see results in TestGrid.

(logs from 225)

```
W0208 23:43:38.899] 2019/02/08 23:43:38 azure.go:366: Creating Azure resource group: kubetest-7ec52a3d-2bf8-11e9-87f5-7aa02df7ac3c-rg for cluster deployment.
W0208 23:43:39.875] 2019/02/08 23:43:39 azure.go:371: Validating deployment ARM templates.
W0208 23:43:45.031] 2019/02/08 23:43:45 azure.go:377: Deploying cluster kubetest-7ec52a3d-2bf8-11e9-87f5-7aa02df7ac3c in resource group kubetest-7ec52a3d-2bf8-11e9-87f5-7aa02df7ac3c-rg.
W0209 00:25:08.507] 2019/02/09 00:25:08 process.go:153: Running: ./cluster/kubectl.sh --match-server-version=false version
W0209 00:25:10.076] 2019/02/09 00:25:10 process.go:155: Step './cluster/kubectl.sh --match-server-version=false version' finished in 1.568996718s
W0209 00:25:10.076] 2019/02/09 00:25:10 process.go:153: Running: ./cluster/kubectl.sh --match-server-version=false get nodes -oyaml
W0209 00:25:11.469] 2019/02/09 00:25:11 process.go:155: Step './cluster/kubectl.sh --match-server-version=false get nodes -oyaml' finished in 1.393303011s
```