### PR TITLE
Updates the taint set in the win-e2e-master-extension

### DIFF
--- a/extensions/master_extension/v1/win-e2e-master-extension.sh
+++ b/extensions/master_extension/v1/win-e2e-master-extension.sh
@@ -2,6 +2,6 @@
 
 master_node=$(kubectl get nodes | grep master | awk '{print $1}')
 
-kubectl taint nodes $master_node key=value:NoSchedule
+kubectl taint nodes $master_node node-role.kubernetes.io/master=:NoSchedule
 kubectl label nodes $master_node node-role.kubernetes.io/master=NoSchedule
 


### PR DESCRIPTION
The taint "key=value:NoSchedule" might get applied before all the pods in the kube-system are up and running, meaning that they will be stuck in a "Pending" state.

The kube-system pods have the tolerange "node-role.kubernetes.io/master", so setting the taint "node-role.kubernetes.io/master=:NoSchedule" instead would be a good idea.