### PR TITLE
Add custom 1.0.16 Azure CNI URL to template.

### DIFF
--- a/job-templates/kubernetes_release.json
+++ b/job-templates/kubernetes_release.json
@@ -3,7 +3,11 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.13"
+      "orchestratorRelease": "1.13",
+      "kubernetesConfig": {
+        "azureCNIURLLinux": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.16.tgz",
+        "azureCNIURLWindows": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.16.tgz"
+      }
     },
     "masterProfile": {
       "count": 1,


### PR DESCRIPTION
Force use of Azure CNI 1.0.16 as version 1.0.17 seems less stable.