### PR TITLE
gb-frontend: Pins apache-httpd and php versions

### DIFF
--- a/images/gb-frontend/Dockerfile
+++ b/images/gb-frontend/Dockerfile
@@ -20,8 +20,8 @@ RUN powershell -Command \
     Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
     choco feature disable --name showDownloadProgress
 RUN powershell -Command \
-    choco install apache-httpd -y; \
-    choco install php -y --params '"/ThreadSafe "'
+    choco install apache-httpd --version 2.4.37 -y; \
+    choco install php --version 7.2.14 -y --params '"/ThreadSafe "'
 RUN powershell -Command \
     $oldpath = (Get-ItemProperty -Path ‘Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment’ -Name PATH).path; \
     $newpath = “$oldpath;c:\tools\php72\;c:\Users\ContainerAdministrator\AppData\Roaming\Apache24\bin\”; \


### PR DESCRIPTION
A new php version has been released (7.3), causing it to install into the folder c:\tools\php73, which different from what the rest of the Dockerfile was using. Because of this, the image was no longer able to start.

This commit pins the installed apache-httpd and php versions.

Fixes: #10