### PR TITLE
Fixing Azure-CNI 1.0.16 URL

### DIFF
--- a/job-templates/kubernetes_release.json
+++ b/job-templates/kubernetes_release.json
@@ -6,7 +6,7 @@
       "orchestratorRelease": "1.13",
       "kubernetesConfig": {
         "azureCNIURLLinux": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.16.tgz",
-        "azureCNIURLWindows": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.16.tgz"
+        "azureCNIURLWindows": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.16.zip"
       }
     },
     "masterProfile": {


### PR DESCRIPTION
I should have double checked those URLs in #14 . They looked right, but the second one was wrong.

Tests:

```
$ curl -o azure-cni.tgz https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.16.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4261k  100 4261k    0     0  4141k      0  0:00:01  0:00:01 --:--:-- 4141k

$ tar tvzf azure-cni.tgz
-rwxr-xr-x root/root   5842912 2019-01-10 22:24 azure-vnet
-rwxr-xr-x root/root   5308960 2019-01-10 22:24 azure-vnet-ipam
-rw-r--r-- root/root       368 2019-01-10 22:24 10-azure.conflist
patrick@planglx1:~/pr14$ curl -o azure-cni.zip https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.16.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4131k  100 4131k    0     0  3984k      0  0:00:01  0:00:01 --:--:-- 3984k

$ unzip -l azure-cni.zip
Archive:  azure-cni.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  5748224  2019-01-10 22:24   azure-vnet.exe
  5282816  2019-01-10 22:24   azure-vnet-ipam.exe
     1300  2019-01-10 22:24   10-azure.conflist
---------                     -------
 11032340                     3 files

```