### PR TITLE
Adds image Manifest lists

### DIFF
--- a/images/image-repo-list
+++ b/images/image-repo-list
@@ -1,0 +1,8 @@
+dockerLibraryRegistry: e2eteam
+e2eRegistry: e2eteam
+gcRegistry: e2eteam
+hazelcastRegistry: e2eteam
+PrivateRegistry: e2eteam
+sampleRegistry: e2eteam
+stormRegistry: e2eteam
+zookeeperRegistry: e2eteam


### PR DESCRIPTION
Adds BuildImageManifestLists.ps1 script which builds and tags the images
based on predefined base images.

At the moment, the base images we're building on top of are:

- microsoft/windowsservercore:1803
- mcr.microsoft.com/windows/servercore:ltsc2019

The script also adds suffixes (1803 and 1809 respectively) to the image
versions. Those images can then be pushed to dockerhub.

Finally, the script will create manifest lists for the images, which can
then be pushed to dockerhub.