### PR TITLE
Correct calculation of CPU usage.

### DIFF
--- a/images/resource-consumer/utils.go
+++ b/images/resource-consumer/utils.go
@@ -34,7 +34,9 @@ func ConsumeCPU(millicores int, durationSec int) {
 	arg1 := fmt.Sprintf("-millicores=%d", millicores)
 	arg2 := fmt.Sprintf("-duration-sec=%d", durationSec)
 	consumeCPU := exec.Command(consumeCPUBinary, arg1, arg2)
-	consumeCPU.Run()
+	if err := consumeCPU.Run(); err != nil {
+		panic(err)
+	}
 }
 
 func ConsumeMem(megabytes int, durationSec int) {


### PR DESCRIPTION
This executable attempts to maintain around a target level of CPU usage.
For that to work, it has to calculate its current usage correctly. The
calculation is based on a syscall that returns the cpu time this process
has used so far. However, the loading of that return value into a struct
was incorrect; by summing each cpu usage value with itself, the estimate
of current cpu usage was doubled. This results in the container using
less than the requested number of millicores.

This commit also makes some variable names more readable and add a
couple comments explaining the purpose of the helper functions. Doing
all calculations in millicores rather than percentages makes the code
more aligned with the input it takes.

Relevant to https://github.com/kubernetes/kubernetes/issues/73489