### PR TITLE
Add separate templates for staging job and main job.

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -3,11 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.14",
-      "kubernetesConfig": {
-        "azureCNIURLLinux": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-v1.0.17.tgz",
-        "azureCNIURLWindows": "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-v1.0.17.zip"
-      }
+      "orchestratorRelease": "1.14"
     },
     "masterProfile": {
       "count": 1,
@@ -37,12 +33,7 @@
     ],
     "windowsProfile": {
       "adminUsername": "azureuser",
-      "adminPassword": "replacepassword1234$",
-      "windowsPublisher": "MicrosoftWindowsServer",
-      "windowsOffer": "WindowsServerSemiAnnual",
-      "windowsSku": "Datacenter-Core-1809-with-Containers-smalldisk",
-      "imageVersion": "1809.0.20190214",
-      "windowsDockerVersion": "18.09.0"
+      "adminPassword": "replacepassword1234$"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
The template for the main job ( kubernetes_template.json ) will
have pinned versions for Windows Image, CNI version and Docker version.
The reason behind the change is to protect the main job against
changes in these components that may affect the success of tests.

The staging job ( with template kubernetes_staging_template.json ) will
be used to experiment with new versions for CNI etc.