### PR TITLE
Adds nc.exe to the busybox image

### DIFF
--- a/images/busybox/Dockerfile
+++ b/images/busybox/Dockerfile
@@ -19,6 +19,7 @@ FROM $BASE_IMAGE
 COPY --from=prep /curl/ /curl
 WORKDIR /busybox
 ADD busybox.exe busybox.exe
+ADD https://github.com/diegocr/netcat/raw/master/nc.exe /busybox/nc.exe
 USER ContainerAdministrator
 RUN FOR /f "tokens=*" %i IN ('busybox --list') DO mklink C:\busybox\%i.exe busybox.exe
 RUN setx /M PATH "C:\busybox;C:\curl\;%PATH%"

--- a/images/hostexec/Dockerfile
+++ b/images/hostexec/Dockerfile
@@ -14,5 +14,4 @@
 
 ARG BASE_IMAGE=e2eteam/busybox:1.29
 FROM $BASE_IMAGE
-ADD https://github.com/diegocr/netcat/raw/master/nc.exe /bin/nc.exe
 ENTRYPOINT ["cmd.exe", "/s", "/c", "sleep", "3600"]


### PR DESCRIPTION
Adds the nc.exe executable to the busybox image, as it is required
by some tests (https://github.com/kubernetes/kubernetes/pull/74290).

Removes nc.exe from the hostexec Dockerfile because the hostexec
image is based on the busybox image, so it will contain the nc.exe.