### PR TITLE
Adds the etcd and sample-apiserver images

### DIFF
--- a/images/InstallDependencies.ps1
+++ b/images/InstallDependencies.ps1
@@ -39,7 +39,8 @@ $goDependencies = @(
     "k8s.io/apiextensions-apiserver",
     "k8s.io/apiserver",
     "k8s.io/client-go/rest",
-    "k8s.io/kubernetes/test"
+    "k8s.io/kubernetes/test",
+    "k8s.io/sample-apiserver"
 )
 
 # Install Go dependencies.
@@ -47,3 +48,8 @@ foreach ($dependency in $goDependencies) {
     Write-Verbose "Installing $dependency"
     go get $dependency
 }
+
+# the sample-apiserver image requires a specific tag.
+pushd $env:GOPATH\src\k8s.io\sample-apiserver
+git checkout --track origin/release-1.10
+popd

--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -258,6 +258,7 @@ $Images = @(
     DockerImage -Name "dnsutils" -ImageBase "busybox" -Versions "1.1"
     DockerImage -Name "echoserver" -ImageBase "busybox" -Versions "2.2"
     DockerImage -Name "entrypoint-tester"
+    DockerImage -Name "etcd" -Versions "v3.3.10"
     DockerImage -Name "fakegitserver"
     DockerImage -Name "gb-frontend" -Versions "v6"
     DockerImage -Name "gb-redisslave" -Versions "v3"

--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -281,6 +281,7 @@ $Images = @(
     DockerImage -Name "resource-consumer" -Versions "1.4"
     DockerImage -Name "resource-consumer/controller"
     DockerImage -Name "rethinkdb" -Version "1.16.0_1" -ImageBase "busybox"
+    DockerImage -Name "sample-apiserver" -Versions "1.10"
     DockerImage -Name "serve-hostname" -Versions "1.1"
     DockerImage -Name "webhook" -Versions "1.13v1"
     DockerImage -Name "zookeeper" -Versions "latest" -ImageBase "java"

--- a/images/etcd/Dockerfile
+++ b/images/etcd/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=microsoft/windowsservercore:1803
+FROM $BASE_IMAGE
+
+ADD https://github.com/etcd-io/etcd/releases/download/v3.3.10/etcd-v3.3.10-windows-amd64.zip /
+RUN powershell -Command "Expand-Archive -Path C:\etcd-v3.3.10-windows-amd64.zip -DestinationPath C:\ -Force ;\
+Rename-Item -Path C:\etcd-v3.3.10-windows-amd64 -NewName C:\etcd" &&\
+del C:\etcd-v3.3.10-windows-amd64.zip
+ENTRYPOINT ["/etcd/etcd.exe"]

--- a/images/sample-apiserver/Dockerfile
+++ b/images/sample-apiserver/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=microsoft/windowsservercore:1803
+FROM $BASE_IMAGE
+ADD sample-apiserver.exe /sample-apiserver.exe
+ENTRYPOINT ["/sample-apiserver.exe"]

--- a/images/sample-apiserver/sample-apiserver.golnk
+++ b/images/sample-apiserver/sample-apiserver.golnk
@@ -1,0 +1,1 @@
+k8s.io/sample-apiserver


### PR DESCRIPTION
Adds the following images:

- etcd
- sample-apiserver

Both images are required by the test: ``[sig-api-machinery] Aggregator Should be able to support the 1.10 Sample API Server using the current Aggregator [Conformance]``