### PR TITLE
Adds  etcdRegistry to image-repo-list

### DIFF
--- a/images/image-repo-list
+++ b/images/image-repo-list
@@ -1,5 +1,6 @@
 dockerLibraryRegistry: e2eteam
 e2eRegistry: e2eteam
+etcdRegistry: e2eteam
 gcRegistry: e2eteam
 hazelcastRegistry: e2eteam
 PrivateRegistry: e2eteam


### PR DESCRIPTION
The PR [1] introduced a new configurable registry for etcd images. The default etcd image does not have Windows support, so we have to use our e2eteam repo instead.

[1] https://github.com/kubernetes/kubernetes/pull/74666