### PR TITLE
Removes zookeeper DockerImage

### DIFF
--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -285,5 +285,4 @@ $Images = @(
     DockerImage -Name "sample-apiserver" -Versions "1.10"
     DockerImage -Name "serve-hostname" -Versions "1.1"
     DockerImage -Name "webhook" -Versions "1.13v1"
-    DockerImage -Name "zookeeper" -Versions "latest" -ImageBase "java"
 )


### PR DESCRIPTION
The image was used by a test that was deleted some time ago. (should create and stop Zookeeper, Nimbus and Storm worker servers, which existed in test/e2e/examples.go).

Since that test was deleted, the image is no longer needed.  The image was WIP, and its Dockerfile wasn't committed.

Fixes #31 