### PR TITLE
tests: Recreates go executables if Recreate is true

### DIFF
--- a/images/BuildImageManifestLists.ps1
+++ b/images/BuildImageManifestLists.ps1
@@ -22,7 +22,7 @@ $VerbosePreference = "continue"
 
 . "$PSScriptRoot\Utils.ps1"
 
-BuildGoFiles $Images.Name
+BuildGoFiles $Images.Name $Recreate
 
 $failedBuildImages = New-Object System.Collections.ArrayList
 $failedPushImages = New-Object System.Collections.ArrayList

--- a/images/BuildImages.ps1
+++ b/images/BuildImages.ps1
@@ -23,7 +23,7 @@ $VerbosePreference = "continue"
 
 . "$PSScriptRoot\Utils.ps1"
 
-BuildGoFiles $Images.Name
+BuildGoFiles $Images.Name $Recreate
 $failedBuildImages = Build-DockerImages $Images $BaseImage $Repository $Recreate
 if ($PushToDocker) {
     $failedPushImages = Push-DockerImages $Images $Repository

--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function BuildGoFiles($folders) {
+function BuildGoFiles($folders, $recreate) {
     Get-Command -ErrorAction Ignore -Name go | Out-Null
     if (!$?) {
         Write-Verbose ("Go is not installed or not found. Skipping building " +
@@ -26,7 +26,7 @@ function BuildGoFiles($folders) {
         $items = Get-ChildItem -Recurse $folder | ? Name -Match ".*.go(lnk)?$" | ? Name -NotMatch "util"
         foreach ($item in $items) {
             $exePath = Join-Path $item.DirectoryName ($item.BaseName + ".exe")
-            if (Test-Path $exePath) {
+            if (!$recreate -and (Test-Path $exePath)) {
                 Write-Verbose "$exePath already exists. Skipping go build for it."
                 continue
             }


### PR DESCRIPTION
At the moment, the go executables are built only once; if the executable
is already found, they will not be rebuilt.

If the go sources are modified, the executables would need to be rebuilt
manually or deleted before recreating the images.

This commit passes the $Recreate flag to the BuildGoFiles function,
which will now rebuild the executables if true.