### PR TITLE
Adds new dependencies to InstallDependencies.ps1

### DIFF
--- a/images/InstallDependencies.ps1
+++ b/images/InstallDependencies.ps1
@@ -39,6 +39,8 @@ $goDependencies = @(
     "k8s.io/apiextensions-apiserver",
     "k8s.io/apiserver",
     "k8s.io/client-go/rest",
+    "k8s.io/component-base/cli/flag",
+    "k8s.io/component-base/logs",
     "k8s.io/kubernetes/test",
     "k8s.io/sample-apiserver"
 )


### PR DESCRIPTION
Some binaries fail to build due to missing dependencies.
Adding them to InstallDependencies.ps1 solves the issue.

Partially Fixes #30 