### PR TITLE
images: Adds --purge to docker manifest push command

### DIFF
--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -169,7 +169,7 @@ Function Push-DockerManifestLists {
         foreach ($version in $image.Versions) {
             $version = "$version$VersionSuffix"
             $fullManifestName = "$Repository/$imgName`:$version"
-            docker manifest push "$fullManifestName" | Write-Verbose
+            docker manifest push --purge "$fullManifestName" | Write-Verbose
 
             if (!$?) {
                 $failedManifests.Add($fullManifestName)


### PR DESCRIPTION
The --purge argument will cause the manifest list to be deleted after it was pushed, allowing a new, fresh, and up to date manifest list to be created next time the BuildImageManifestLists.ps1 is called.

Fixes:  #40