### PR TITLE
images: Updates Cassandra binary version to 3.11.4

### DIFF
--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -16,14 +16,14 @@ ARG BASE_IMAGE=e2eteam/java:openjdk-8-jre
 FROM $BASE_IMAGE
 
 # install CassandraDB.
-ENV CASSANDRA_VERSION 3.11.3
+ENV CASSANDRA_VERSION 3.11.4
 RUN mkdir C:\cassandra_data
 ADD run.sh /run.sh
 ADD ready-probe.sh /ready-probe.sh
 ADD http://apache.mirror.anlx.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz /apache-cassandra-bin.tar.gz
 ADD https://github.com/samsung-cnct/cassandra-container/raw/master/kubernetes/cassandra/kubernetes-cassandra.jar /kubernetes-cassandra.jar
 RUN tar -xzf C:/apache-cassandra-bin.tar.gz -C C:/ && \
-move C:\apache-cassandra-3.11.3 C:\cassandra && \
+move C:\apache-cassandra-3.11.4 C:\cassandra && \
 mkdir C:\cassandra\logs && \
 del C:\apache-cassandra-bin.tar.gz
 


### PR DESCRIPTION
Cassandra 3.11.3 has been unpublished, so the image now fails to
build.

Updates the downloaded binary to a newer version.

Partially Fixes: #30