### PR TITLE
Revert "Update staging template to include azure-cni 1.0.18"

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -3,11 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.14",
-      "kubernetesConfig": {
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/archive/v1.0.18.tar.gz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/archive/v1.0.18.zip"
-      }
+      "orchestratorRelease": "1.14"
     },
     "masterProfile": {
       "count": 1,


### PR DESCRIPTION
This reverts commit 709d830022f320825f4851e7eda66c884fba0d4d.

Reason: staging job fails, azure-cni v1.0.18 does not seem to work. 