### PR TITLE
images: Adds example-dns images

### DIFF
--- a/images/BuildImageManifestLists.ps1
+++ b/images/BuildImageManifestLists.ps1
@@ -23,6 +23,7 @@ $VerbosePreference = "continue"
 . "$PSScriptRoot\Utils.ps1"
 
 BuildGoFiles $Images.Name $Recreate
+CopyPythonFiles $Images.Name
 
 $failedBuildImages = New-Object System.Collections.ArrayList
 $failedPushImages = New-Object System.Collections.ArrayList

--- a/images/BuildImages.ps1
+++ b/images/BuildImages.ps1
@@ -24,6 +24,21 @@ $VerbosePreference = "continue"
 . "$PSScriptRoot\Utils.ps1"
 
 BuildGoFiles $Images.Name $Recreate
+CopyPythonFiles $Images.Name
+
+# we are trying to use an external image for the Python-based images, so we
+# have to retag the "python:3.7.2-windowsservercore" based on the given
+# $BaseImage.
+foreach ($base in $BaseImages) {
+    if ($BaseImage -eq $base.Name) {
+        $basePython = "python:3.7.2-windowsservercore"
+        $suffix = $base.Suffix
+        $actualImageName = "$basePython$suffix"
+        Write-Verbose "Retagging $actualImageName as $basePython"
+        docker tag $actualImageName $basePython
+    }
+}
+
 $failedBuildImages = Build-DockerImages $Images $BaseImage $Repository $Recreate
 if ($PushToDocker) {
     $failedPushImages = Push-DockerImages $Images $Repository

--- a/images/InstallDependencies.ps1
+++ b/images/InstallDependencies.ps1
@@ -41,6 +41,7 @@ $goDependencies = @(
     "k8s.io/client-go/rest",
     "k8s.io/component-base/cli/flag",
     "k8s.io/component-base/logs",
+    "k8s.io/examples",
     "k8s.io/kubernetes/test",
     "k8s.io/sample-apiserver"
 )

--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -44,6 +44,17 @@ function BuildGoFiles($folders, $recreate) {
     }
 }
 
+function CopyPythonFiles($folders) {
+    Write-Verbose "Copying Python files..."
+    foreach ($folder in $folders) {
+        $items = Get-ChildItem -Recurse $folder | ? Name -Match ".*.pylnk?$"
+        foreach ($item in $items) {
+            $source = (cat "$folder/$item").Trim()
+            cp $env:GOPATH/src/$source $folder/
+        }
+    }
+}
+
 Function Build-DockerImages {
     Param (
       [Parameter(Mandatory=$true)]  [PSObject[]]$Images,
@@ -246,7 +257,6 @@ function DockerImage
     $image
 }
 
-
 $Images = @(
     # base images used to build other images.
     DockerImage -Name "busybox" -Versions "1.29"
@@ -259,6 +269,8 @@ $Images = @(
     DockerImage -Name "echoserver" -ImageBase "busybox" -Versions "2.2"
     DockerImage -Name "entrypoint-tester"
     DockerImage -Name "etcd" -Versions "v3.3.10"
+    DockerImage -Name "example-dns-backend" -Versions "v1" -ImageBase "python:3.7.2-windowsservercore"
+    DockerImage -Name "example-dns-frontend" -Versions "v1" -ImageBase "python:3.7.2-windowsservercore"
     DockerImage -Name "fakegitserver"
     DockerImage -Name "gb-frontend" -Versions "v6"
     DockerImage -Name "gb-redisslave" -Versions "v3"

--- a/images/example-dns-backend/Dockerfile
+++ b/images/example-dns-backend/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=python:3.7.2-windowsservercore-1803
+FROM $BASE_IMAGE
+
+COPY . /dns-backend
+WORKDIR /dns-backend
+
+CMD ["python", "server.py"]

--- a/images/example-dns-backend/server.py
+++ b/images/example-dns-backend/server.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http.server import BaseHTTPRequestHandler,HTTPServer
+
+PORT_NUMBER = 8000
+
+# This class will handles any incoming request.
+class HTTPHandler(BaseHTTPRequestHandler):
+  # Handler for the GET requests
+  def do_GET(self):
+    self.send_response(200)
+    self.send_header('Content-type','text/html')
+    self.end_headers()
+    self.wfile.write(b"Hello World!")
+
+try:
+  # Create a web server and define the handler to manage the incoming request.
+  server = HTTPServer(('', PORT_NUMBER), HTTPHandler)
+  print('Started httpserver on port ', PORT_NUMBER)
+  server.serve_forever()
+except KeyboardInterrupt:
+  print('^C received, shutting down the web server')
+  server.socket.close()

--- a/images/example-dns-backend/server.pylnk
+++ b/images/example-dns-backend/server.pylnk
@@ -1,0 +1,1 @@
+k8s.io/examples/staging/cluster-dns/images/backend/server.py

--- a/images/example-dns-frontend/Dockerfile
+++ b/images/example-dns-frontend/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=python:3.7.2-windowsservercore-1803
+FROM $BASE_IMAGE
+
+RUN pip install requests
+
+COPY . /dns-frontend
+WORKDIR /dns-frontend
+
+CMD ["python", "client.py"]

--- a/images/example-dns-frontend/client.py
+++ b/images/example-dns-frontend/client.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import requests
+import socket
+import sys
+
+if sys.version_info[0] < 3:
+  from urlparse import urlparse
+else:
+  from urllib.parse import urlparse
+
+
+def CheckServiceAddress(address):
+  hostname = urlparse(address).hostname
+  service_address = socket.gethostbyname(hostname)
+  print(service_address)
+
+
+def GetServerResponse(address):
+  print('Send request to:', address)
+  response = requests.get(address)
+  print(response)
+  print(response.content)
+
+
+def Main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('address')
+  args = parser.parse_args()
+  CheckServiceAddress(args.address)
+  GetServerResponse(args.address)
+
+
+if __name__ == "__main__":
+  Main()

--- a/images/example-dns-frontend/client.pylnk
+++ b/images/example-dns-frontend/client.pylnk
@@ -1,0 +1,1 @@
+k8s.io/examples/staging/cluster-dns/images/frontend/client.py


### PR DESCRIPTION
The images are needed by the test:

[sig-network] ClusterDns [Feature:Example] should create pod that uses dns

The images use python scripts, so we have to add them to the image from
the kubernetes/examples repo.

There already are official python images for both Windows Server 1803
and 2019, so we can build on top of them.