### PR TITLE
images: Adds iperf image

### DIFF
--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -264,6 +264,7 @@ $Images = @(
     DockerImage -Name "gb-redisslave" -Versions "v3"
     DockerImage -Name "hazelcast-kubernetes" -Versions "3.8_1" -ImageBase "java"
     DockerImage -Name "hostexec" -Versions "1.1" -ImageBase "busybox"
+    DockerImage -Name "iperf" -ImageBase "busybox"
     DockerImage -Name "jessie-dnsutils" -ImageBase "busybox"
     DockerImage -Name "kitten" -ImageBase "test-webserver"
     DockerImage -Name "liveness" -Versions "1.1"

--- a/images/iperf/Dockerfile
+++ b/images/iperf/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=e2eteam/busybox:1.29
+FROM $BASE_IMAGE
+
+RUN powershell -Command "\
+    wget -uri 'https://iperf.fr/download/windows/iperf-2.0.9-win64.zip' -OutFile 'C:\iperf.zip';\
+    Expand-Archive -Path C:\iperf.zip -DestinationPath C:\ -Force;\
+    Rename-Item C:\iperf-2.0.9-win64 C:\iperf;\
+    Remove-Item 'C:\iperf.zip'"
+
+USER ContainerAdministrator
+RUN mkdir C:\usr\local && mklink /D C:\usr\local\bin C:\iperf
+USER ContainerUser


### PR DESCRIPTION
The image is required for the tests:

    [sig-network] Networking IPerf IPv6 [Experimental][Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)
    [sig-network] Networking IPerf IPv4 [Experimental][Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)

The tests are running /bin/bash, so basing the image on busybox is required.