### PR TITLE
Fixed versioning and executable path

### DIFF
--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -258,7 +258,7 @@ $Images = @(
     DockerImage -Name "dnsutils" -ImageBase "busybox" -Versions "1.1"
     DockerImage -Name "echoserver" -ImageBase "busybox" -Versions "2.2"
     DockerImage -Name "entrypoint-tester"
-    DockerImage -Name "etcd" -Versions "v3.3.10"
+    DockerImage -Name "etcd" -Versions "v3.3.10", "3.3.10"
     DockerImage -Name "fakegitserver"
     DockerImage -Name "gb-frontend" -Versions "v6"
     DockerImage -Name "gb-redisslave" -Versions "v3"

--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -64,7 +64,7 @@ Function Build-DockerImages {
             $fullImageName = "$Repository/$imgName`:$version"
 
             if (!$Recreate) {
-                $imageFound = $allDockerImages | findstr "$Repository/$imgName" | findstr $version
+                $imageFound = $allDockerImages | Select-String -Pattern "$Repository/$imgName" | Select-String -Pattern "\s$version\s"
                 if ($imageFound) {
                     Write-Verbose "Image ""$fullImageName"" already exists. Skipping."
                     continue

--- a/images/etcd/Dockerfile
+++ b/images/etcd/Dockerfile
@@ -16,7 +16,7 @@ ARG BASE_IMAGE=microsoft/windowsservercore:1803
 FROM $BASE_IMAGE
 
 ADD https://github.com/etcd-io/etcd/releases/download/v3.3.10/etcd-v3.3.10-windows-amd64.zip /
-RUN powershell -Command "Expand-Archive -Path C:\etcd-v3.3.10-windows-amd64.zip -DestinationPath C:\ -Force ;\
-Rename-Item -Path C:\etcd-v3.3.10-windows-amd64 -NewName C:\etcd" &&\
+RUN powershell -Command "Expand-Archive -Path C:\etcd-v3.3.10-windows-amd64.zip -DestinationPath C:\usr\local -Force ;\
+Rename-Item -Path C:\usr\local\etcd-v3.3.10-windows-amd64 -NewName C:\usr\local\bin" &&\
 del C:\etcd-v3.3.10-windows-amd64.zip
-ENTRYPOINT ["/etcd/etcd.exe"]
+ENTRYPOINT ["/usr/local/bin/etcd.exe"]


### PR DESCRIPTION
Fixes issue #52 

Changed versioning to support both `v3.3.10` and `3.3.10`

Changed [path](https://github.com/kubernetes-sigs/windows-testing/commit/70911aa7949df762d885426a95858d461603c811#diff-a82fdf09246795a2a5daca6708f7aa5eR22) of `etcd.exe` from images/etcd/Dockerfile to fit the [new path](https://github.com/kubernetes/kubernetes/commit/175dcdb3d67dddefcd35e1f7be7cab7e3c3f3483?diff=split#diff-c944d1288edcaf37beebab811603bfd8R220)