### PR TITLE
Update staging template docker version.

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -3,11 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.14",
-      "kubernetesConfig": {
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.18-rc3/azure-vnet-cni-linux-amd64-v1.0.18-rc3.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.18-rc3/azure-vnet-cni-windows-amd64-v1.0.18-rc3.zip"
-      }
+      "orchestratorRelease": "1.14"
     },
     "masterProfile": {
       "count": 1,
@@ -38,7 +34,7 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
-      "windowsDockerVersion": "18.09.2",
+      "windowsDockerVersion": "18.09.5",
       "sshEnabled": true
     },
     "linuxProfile": {


### PR DESCRIPTION
Update staging template for aks-engine based jobs. This PR update Docker version. It also removes the custom azure-cni version as the released version v1.0.18 is already contained in newer versions of aks-engine.