### PR TITLE
Add custom azure-cni version back to staging template.

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -3,7 +3,11 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.14"
+      "orchestratorRelease": "1.14",
+      "kubernetesConfig": {
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.18/azure-vnet-cni-linux-amd64-v1.0.18.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.18/azure-vnet-cni-windows-amd64-v1.0.18.zip"
+      }
     },
     "masterProfile": {
       "count": 1,


### PR DESCRIPTION
The custom version was removed as the staging job was updated
to use aks-engine version 0.34.0 that defaults azure-cni to v1.0.18.
However, since that version of aks-engine does not properly handle
custom extensions scripts we have to revert to a known working
aks-engine version for the job, via:

https://github.com/kubernetes/test-infra/pull/12238