### PR TITLE
Set last known working Windows version for staging

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -38,6 +38,10 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
+      "windowsPublisher": "MicrosoftWindowsServer",
+      "windowsOffer": "WindowsServerSemiAnnual",
+      "windowsSku": "Datacenter-Core-1809-with-Containers-smalldisk",
+      "imageVersion": "1809.0.20190314",
       "windowsDockerVersion": "18.09.2",
       "sshEnabled": true
     },


### PR DESCRIPTION
Staging job continues to fail consistently. We set last known working windows image version ( "1809.0.20190314" : kernel version: 10.0.17763.379 ) in a further attempt to bring the job back to the last known working state.