### PR TITLE
images: Adds CoreDNS to dnsutils and jessie-dnsutils

### DIFF
--- a/images/Utils.ps1
+++ b/images/Utils.ps1
@@ -255,7 +255,7 @@ $Images = @(
     DockerImage -Name "test-webserver"
 
     DockerImage -Name "cassandra" -Versions "v13" -ImageBase "java"
-    DockerImage -Name "dnsutils" -ImageBase "busybox" -Versions "1.1"
+    DockerImage -Name "dnsutils" -ImageBase "busybox" -Versions "1.2"
     DockerImage -Name "echoserver" -ImageBase "busybox" -Versions "2.2"
     DockerImage -Name "entrypoint-tester"
     DockerImage -Name "etcd" -Versions "v3.3.10", "3.3.10"
@@ -265,7 +265,7 @@ $Images = @(
     DockerImage -Name "hazelcast-kubernetes" -Versions "3.8_1" -ImageBase "java"
     DockerImage -Name "hostexec" -Versions "1.1" -ImageBase "busybox"
     DockerImage -Name "iperf" -ImageBase "busybox"
-    DockerImage -Name "jessie-dnsutils" -ImageBase "busybox"
+    DockerImage -Name "jessie-dnsutils" -ImageBase "busybox"  -Versions "1.1"
     DockerImage -Name "kitten" -ImageBase "test-webserver"
     DockerImage -Name "liveness" -Versions "1.1"
     DockerImage -Name "logs-generator"

--- a/images/dnsutils/Dockerfile
+++ b/images/dnsutils/Dockerfile
@@ -22,4 +22,8 @@ choco feature disable --name showDownloadProgress
 ADD hostname.exe /busybox/hostname.exe
 ADD getent.exe /busybox/getent.exe
 RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
+RUN powershell -Command "\
+    wget -uri 'https://github.com/coredns/coredns/releases/download/v1.5.0/coredns_1.5.0_windows_amd64.tgz' -OutFile 'C:\coredns.tgz';\
+    tar -xzvf 'C:\coredns.tgz';\
+    Remove-Item 'C:\coredns.tgz'"
 ENTRYPOINT ["cmd.exe", "/s", "/c"]

--- a/images/jessie-dnsutils/Dockerfile
+++ b/images/jessie-dnsutils/Dockerfile
@@ -22,4 +22,8 @@ choco feature disable --name showDownloadProgress
 ADD hostname.exe /busybox/hostname.exe
 ADD getent.exe /busybox/getent.exe
 RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
+RUN powershell -Command "\
+    wget -uri 'https://github.com/coredns/coredns/releases/download/v1.5.0/coredns_1.5.0_windows_amd64.tgz' -OutFile 'C:\coredns.tgz';\
+    tar -xzvf 'C:\coredns.tgz';\
+    Remove-Item 'C:\coredns.tgz'"
 ENTRYPOINT ["cmd.exe", "/s", "/c"]


### PR DESCRIPTION
Some images require a custom DNS server. Previously, it was using dnsmasq, which is Linux-specific, but it has been replaced with CoreDNS, which can also run on Windows.

This commit adds CoreDNS to the dnsutils and jessie-dnsutils images.