### PR TITLE
Removes image-repo-list extra files

### DIFF
--- a/images/image-repo-list-ws1803
+++ b/images/image-repo-list-ws1803
@@ -1,8 +1,0 @@
-dockerLibraryRegistry: e2eteam
-e2eRegistry: e2eteam
-gcRegistry: e2eteam
-hazelcastRegistry: e2eteam
-PrivateRegistry: e2eteam
-sampleRegistry: e2eteam
-stormRegistry: e2eteam
-zookeeperRegistry: e2eteam

--- a/images/image-repo-list-ws2019
+++ b/images/image-repo-list-ws2019
@@ -1,8 +1,0 @@
-dockerLibraryRegistry: claudiubelu
-e2eRegistry: claudiubelu
-gcRegistry: claudiubelu
-hazelcastRegistry: claudiubelu
-PrivateRegistry: claudiubelu
-sampleRegistry: claudiubelu
-stormRegistry: claudiubelu
-zookeeperRegistry: claudiubelu


### PR DESCRIPTION
We previously had separate repo list files per Windows version, but since we've added manifest list support to the build scripts, they are no longer necessary, only the image-repo-list file, containing just the e2eteam registry, should be used.