### PR TITLE
Remove sshEnabled from staging template

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -53,8 +53,7 @@
       "windowsPublisher": "MicrosoftWindowsServer",
       "windowsOffer": "WindowsServer",
       "windowsSku": "Datacenter-Core-1809-with-Containers-smalldisk",
-      "imageVersion": "17763.557.20190604",
-      "sshEnabled": true
+      "imageVersion": "17763.557.20190604"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
sshEnabled doesn't currently work with June Windows Image. Removing until we fix the issue in aks-engine.