### PR TITLE
Copy index.html to right path in httpd image

### DIFF
--- a/images/httpd/Dockerfile
+++ b/images/httpd/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir C:\usr\local &&\
     mklink /D C:\usr\local\apache2 C:\Users\ContainerAdministrator\AppData\Roaming\Apache24
 
 COPY httpd.conf /Users/ContainerAdministrator/AppData/Roaming/Apache24/conf/httpd.conf
-COPY index.html /Users/ContainerAdministrator/AppData/Roaming/Apache24/conf/index.html
+COPY index.html /Users/ContainerAdministrator/AppData/Roaming/Apache24/htdocs/index.html
 
 EXPOSE 80
 USER ContainerAdministrator


### PR DESCRIPTION
Copies index.html to htdocs in Dockerfile.

Fixes: https://github.com/kubernetes-sigs/windows-testing/issues/93