### PR TITLE
Create test-known-issues.md

### DIFF
--- a/test-known-issues.md
+++ b/test-known-issues.md
@@ -1,0 +1,13 @@
+The intention of this document is to track Conformance tests that are temporarily exluded from test runs and 
+to document the reason behind this.
+
+07/28/2019
+
+Excluded from all master runs:
+* [sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs [Conformance]
+  * Reason: https://github.com/kubernetes/kubernetes/issues/80265
+  * Proposed fix: https://github.com/kubernetes/kubernetes/pull/80516
+  * Short summary of fix: Changing the test to use a image that is works well for both Linux and Windows.
+* [sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application [Conformance]
+  * Reason: https://github.com/kubernetes/kubernetes/issues/80534
+  * Proposed fix: TBD


### PR DESCRIPTION
Create a document to centralise any known issues in the tests and the proposed fixes, as well as tracking exclusions and the reasoning behind them. 

We should centralise all known information about tests on Windows to have as a reference for any reviewer/user who might be interested in the failures. Similar to what we are doing with aks-engine versions used in testing.