### PR TITLE
Update orchestrator version for master templates.

### DIFF
--- a/job-templates/kubernetes_master.json
+++ b/job-templates/kubernetes_master.json
@@ -3,7 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.15",
+      "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.22/azure-vnet-cni-linux-amd64-v1.0.22.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.22/azure-vnet-cni-windows-amd64-v1.0.22.zip",

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -3,7 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.15",
+      "orchestratorRelease": "1.16",
       "kubernetesConfig": {
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.22/azure-vnet-cni-linux-amd64-v1.0.22.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.22/azure-vnet-cni-windows-amd64-v1.0.22.zip",


### PR DESCRIPTION
Update orchestrator version to 1.16 to reflect support in newer aks-engine versions.