### PR TITLE
test: Creates AD Domain for GMSA e2e testing

### DIFF
--- a/extensions/gmsa-dc/README.md
+++ b/extensions/gmsa-dc/README.md
@@ -1,0 +1,69 @@
+# gMSA-DC Extension
+
+This extension will create an Active Directory Forest and Domain using one of the agents nodes.  It will also create a Group Managed Service Account (gMSA) 
+and create the needed YAML file for creation of the gMSA credential spec resource.  This should be used in conjunction with the gmsa-member extension, 
+however, it is not neccessary.
+
+It is required to make a separate pool of 1 member to house the DC for gMSA testing.
+
+# Configuration
+
+|Name               |Required|Acceptable Value     |
+|-------------------|--------|---------------------|
+|name               |yes     |gmsa-dc              |
+|version            |yes     |v1                   |
+|rootURL            |optional|                     |
+
+# Example
+
+```
+    ...
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 2
+		...
+      },
+	  {
+        "name": "windowsgmsa",
+		"count": 1
+        "extensions": [
+          {
+            "name": "gmsa-dc"
+          }
+        ]
+      }
+    ],
+    ...
+    "extensionProfiles": [
+      {
+        "name": "gmsa-dc",
+        "version": "v1"
+      }
+    ]
+    ...
+```
+
+
+# Supported Orchestrators
+
+Kubernetes
+
+# Troubleshoot
+
+The three scripts that run use PowerShell transcripts.  They log to the following directory
+```sh
+C:\gmsa
+```
+
+Extension execution output is logged to files found under the following directory on the target virtual machine.
+
+```sh
+C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension
+```
+
+The specified files are downloaded into the following directory on the target virtual machine.
+
+```sh
+C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\1.*\Downloads\<n>
+```

--- a/extensions/gmsa-dc/v1/Promote-DC.ps1
+++ b/extensions/gmsa-dc/v1/Promote-DC.ps1
@@ -1,0 +1,65 @@
+<#
+ .SYNOPSIS
+ This script will automate the creation of a Forest, Domain, and Domain Controller
+
+ .NOTES
+ This is only for automated e2e testing.  DO NOT use this for production.
+ Jeremy Wood (JeremyWx)
+ Version: 1.0.0.0
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+#Set script variables - These will need changed if this extension is moved to a new repo!!!
+$GMSARoot = "C:\gmsa"
+$ScriptURL = "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/extensions/gmsa-dc/v1"
+
+
+# Create a working directory and change to it
+mkdir $GMSARoot
+Set-Location -Path $GMSARoot
+
+# Logging for troubleshooting
+Start-Transcript -Path "$GMSARoot\Promote.txt"
+
+# Download gMSA Setup Script
+Invoke-WebRequest -UseBasicParsing $ScriptURL/Setup-gMSA.ps1 -OutFile Setup-gMSA.ps1
+
+#Install NuGet
+Install-PackageProvider -Name NuGet -Force
+
+#Create Local Administrator
+$admpassword = ( "K8s" + -join ((48..57) + (97..122) | Get-Random -Count 64 | ForEach-Object {[char]$_}) )
+$admpassword_secure = ( $admpassword | ConvertTo-SecureString -AsPlainText -Force)
+$admpassword | Add-Content -Path $GMSARoot\admin.txt
+New-LocalUser -Name gmsa-admin -Password $admpassword_secure
+Add-LocalGroupMember -Group "Administrators" -Member gmsa-admin
+
+
+# Make Setup-gMSA run on next boot
+$Logon = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
+$RunOnce = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce"
+Set-ItemProperty $Logon "AutoAdminLogon" -Value "1" -type String
+Set-ItemProperty $Logon "AutoLogonCount" -Value "2" -type DWord
+Set-ItemProperty $Logon "DefaultUsername" -Value "k8sgmsa\gmsa-admin" -type String
+Set-ItemProperty $Logon "DefaultPassword" -Value "$admpassword" -type String
+New-ItemProperty $RunOnce "gmsa" -Value "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -command $GMSARoot\Setup-gMSA.ps1" -Type String
+
+# Install and Enable SSH Server
+$SSHService = Get-WindowsCapability -Online | Where-Object Name -like "OpenSSH.Server*"
+Add-WindowsCapability -Online -Name $SSHService.Name
+Start-Service -Name "sshd"
+Set-Service -Name "sshd" -StartupType Automatic 
+# In case of firewall
+New-NetFirewallRule -Name "SSH Server" -DisplayName "SSH Server" -Description "Allow SSH Inbound" -Profile Any -Direction Inbound -Action Allow -Protocol TCP -Program Any -LocalAddress Any -RemoteAddress Any -LocalPort 22 -RemotePort Any 
+
+# Import ServerManager and install the bits for ADDS
+Import-Module ServerManager
+Add-WindowsFeature -Name Web-Server
+Add-WindowsFeature -Name AD-Domain-Services,DNS -IncludeManagementTools
+# Create new Forest and Domain with new DC and DNS
+Install-ADDSForest -DomainName k8sgmsa.lan -SafeModeAdministratorPassword $admpassword_secure -InstallDNS -DomainMode 6 -DomainNetbiosName k8sgmsa -ForestMode 6 -Confirm:$false
+
+

--- a/extensions/gmsa-dc/v1/Setup-gMSA.ps1
+++ b/extensions/gmsa-dc/v1/Setup-gMSA.ps1
@@ -1,0 +1,278 @@
+﻿<#
+ .SYNOPSIS
+ This script will automate the creation of a Group Managed Service Account,
+ install the account locally, produce the JSON file with gMSA info, and convert
+ it to the Yaml file needed.
+
+ .NOTES
+ This is only for automated e2e testing.  DO NOT use this for production.
+ Jeremy Wood (JeremyWx)
+ Version: 1.0.0.0
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Set script variables
+$GMSARoot = "C:\gmsa"
+
+# Function to check AD services
+function CheckADServices()
+	{
+	Sleep 4
+	$svcs = "adws","dns","kdc","netlogon","ntds","lanmanserver","lanmanworkstation"
+    $svcstatus = 0
+        foreach ( $svc in $svcs ) {
+            if ( $(Get-Service -Name $svc).Status -notlike "Running") {
+                $svcstatus += 1
+            }
+        }
+
+    if ($svcstatus -gt 0) {
+        return $false
+        } else {
+        return $true
+        }
+    }
+
+# Function to make sure AD is fully up
+function CheckGroup()
+    {
+    try {
+        Sleep 2
+        $x = Get-AdGroupMember -Identity "Enterprise Admins"
+        return $true
+    } catch {
+        return $false
+        }
+    }
+
+# Function to import Active Directory PowerShell module without error
+function ImportADPS()
+    {
+    try {
+        Import-Module ActiveDirectory
+        return $true
+    } catch {
+        return $false
+        }
+    }
+	
+function New-CredentialSpec {
+
+    <#
+    This function was borrowed from https://github.com/MicrosoftDocs/Virtualization-Documentation/blob/master/windows-server-container-tools/ServiceAccounts/CredentialSpec.psm1
+	#>
+
+    [CmdletBinding(DefaultParameterSetName = "DefaultPath")]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [String]
+        $AccountName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "CustomPath")]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $false, ParameterSetName = "DefaultPath")]
+        [Alias("Name")]
+        [String]
+        $FileName,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Domain,
+
+        [Parameter(Mandatory = $false)]
+        [object[]]
+        $AdditionalAccounts,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $NoClobber = $false
+    )
+
+    # Validate domain information
+    if ($Domain) {
+        $ADDomain = Get-ADDomain -Server $Domain -ErrorAction Continue
+
+        if (-not $ADDomain) {
+            Write-Error "The specified Active Directory domain ($Domain) could not be found.`nCheck your network connectivity and domain trust settings to ensure the current user can authenticate to a domain controller in that domain."
+            return
+        }
+    } else {
+        # Use the logged on user's domain if an explicit domain name is not provided
+        $ADDomain = Get-ADDomain -Current LocalComputer -ErrorAction Continue
+
+        if (-not $ADDomain) {
+            Write-Error "An error ocurred while loading information for the computer account's domain.`nCheck your network connectivity to ensure the computer can authenticate to a domain controller in this domain."
+            return
+        }
+
+        $Domain = $ADDomain.DNSRoot
+	}
+    # Clean up account names and validate formatting
+    $AccountName = $AccountName.TrimEnd('$')
+
+    if ($AdditionalAccounts) {
+        $AdditionalAccounts = $AdditionalAccounts | ForEach-Object {
+            if ($_ -is [hashtable]) {
+                # Check for AccountName and Domain keys
+                if (-not $_.AccountName -or -not $_.Domain) {
+                    Write-Error "Invalid additional account specified: $_`nExpected a samAccountName or a hashtable containing AccountName and Domain keys."
+                    return
+                }
+                else {
+
+                    @{
+                        AccountName = $_.AccountName.TrimEnd('$')
+                        Domain = $_.Domain
+                    }
+                }
+            }
+            elseif ($_ -is [string]) {
+                @{
+                    AccountName = $_.TrimEnd('$')
+                    Domain = $Domain
+                }
+            }
+            else {
+                Write-Error "Invalid additional account specified: $_`nExpected a samAccountName or a hashtable containing AccountName and Domain keys."
+                return
+            }
+        }
+    }
+
+    # Get the location to store the cred spec file either from input params or helper function
+    if ($Path) {
+        $CredSpecRoot = Split-Path $Path -Parent
+        $FileName = Split-Path $Path -Leaf
+    } else {
+        $CredSpecRoot = "C:\ProgramData\docker\credentialspecs"
+    }
+
+    if (-not $FileName) {
+        $FileName = "{0}_{1}" -f $ADDomain.NetBIOSName.ToLower(), $AccountName.ToLower()
+    }
+
+    $FullPath = Join-Path $CredSpecRoot "$($FileName.TrimEnd(".json")).json"
+    if ((Test-Path $FullPath) -and $NoClobber) {
+        Write-Error "A credential spec already exists with the name `"$FileName`".`nRemove the -NoClobber switch to overwrite this file or select a different name using the -FileName parameter."
+        return
+    }
+
+    # Start hash table for output
+    $output = @{}
+
+    # Create ActiveDirectoryConfig Object
+    $output.ActiveDirectoryConfig = @{}
+    $output.ActiveDirectoryConfig.GroupManagedServiceAccounts = @( @{"Name" = $AccountName; "Scope" = $ADDomain.DNSRoot } )
+    $output.ActiveDirectoryConfig.GroupManagedServiceAccounts += @{"Name" = $AccountName; "Scope" = $ADDomain.NetBIOSName }
+    if ($AdditionalAccounts) {
+        $AdditionalAccounts | ForEach-Object {
+            $output.ActiveDirectoryConfig.GroupManagedServiceAccounts += @{"Name" = $_.AccountName; "Scope" = $_.Domain }
+        }
+    }
+    
+    # Create CmsPlugins Object
+    $output.CmsPlugins = @("ActiveDirectory")
+
+    # Create DomainJoinConfig Object
+    $output.DomainJoinConfig = @{}
+    $output.DomainJoinConfig.DnsName = $ADDomain.DNSRoot
+    $output.DomainJoinConfig.Guid = $ADDomain.ObjectGUID
+    $output.DomainJoinConfig.DnsTreeName = $ADDomain.Forest
+    $output.DomainJoinConfig.NetBiosName = $ADDomain.NetBIOSName
+    $output.DomainJoinConfig.Sid = $ADDomain.DomainSID.Value
+    $output.DomainJoinConfig.MachineAccountName = $AccountName
+
+    $output | ConvertTo-Json -Depth 5 | Out-File -FilePath $FullPath -Encoding ascii -NoClobber:$NoClobber
+	
+	Install-Module powershell-yaml -Force
+
+    $CredSpecJson = Get-Item $FullPath | Select-Object @{
+        Name       = 'Name'
+        Expression = { $_.Name }
+    },
+    @{
+        Name       = 'Path'
+        Expression = { $_.FullName }
+    }
+	
+	# This section of code borrowed from https://github.com/kubernetes-sigs/windows-gmsa/blob/master/scripts/GenerateCredentialSpecResource.ps1
+    $dockerCredSpecPath = $CredSpecJson.Path
+    Sleep 2
+    $credSpecContents = Get-Content $dockerCredSpecPath | ConvertFrom-Json
+    $ManifestFile = "gmsa-cred-spec-gmsa-e2e.yml"
+	
+	# generate the k8s resource
+    $resource = [ordered]@{
+        "apiVersion" = "windows.k8s.io/v1alpha1";
+        "kind" = 'GMSACredentialSpec';
+        "metadata" = @{
+        "name" = $AccountName
+        };
+        "credspec" = $credSpecContents
+    }
+
+ConvertTo-Yaml $resource | Set-Content $ManifestFile
+
+Write-Output "K8S manifest rendered at $ManifestFile"
+}
+
+# Change to working directory
+Set-Location -Path $GMSARoot
+
+# Script Logging - Feel free to comment out if you like.
+Start-Transcript -Path "$GMSARoot\Setup-gmsa.txt" -Append
+# Making sure the AD services are up and running
+do {$ADresult = CheckADServices} while ($ADresult -eq $false)
+
+# Import Active Directory PowerShell module
+do {$ADPSresult = ImportADPS} while ($ADPSresult -eq $false)
+
+# Make sure AD server instance is listening on port
+do {$CGresult = CheckGroup} while ($CGresult -eq $false)
+
+
+if (Get-AdGroupMember -Identity "Enterprise Admins" | Select-String -Pattern "gmsa-admin" -Quiet) {
+    
+    # Add the KDS Root Key
+    $KdsRootKey = Get-KdsRootKey
+    if ($KdsRootKey -eq $null) {
+        # This command creates the KDS Root Key with a time 10 hours in the past.
+        # Active Directory will not permit use of this key until at least 10 hours has
+        # passed to allow distribution to all Domain Controllers in the domain.
+        # https://docs.microsoft.com/en-us/windows-server/security/group-managed-service-accounts/create-the-key-distribution-services-kds-root-key
+        Add-KdsRootKey –EffectiveTime ((get-date).addhours(-10))
+        # Make sure we are PAST the 10 hour mark
+        Start-Sleep -Seconds 15
+    }
+    
+    # Directory for credspecs if not already created
+    mkdir -Path C:\ProgramData\docker\credentialspecs -ErrorAction SilentlyContinue
+
+    # Import AD Module and Setup gMSA
+    New-ADServiceAccount -Name gmsa-e2e -DNSHostName gmsa-e2e.k8sgmsa.lan -PrincipalsAllowedToRetrieveManagedPassword "Domain Computers" -ServicePrincipalnames http/gmsa-e2e.k8sgmsa.lan
+
+    # Run New-CredntialSpec to provide the Yaml CredSpec
+    New-CredentialSpec -Name gmsa-e2e -AccountName gmsa-e2e
+	
+    # Copy files to make them available for download
+	Copy-Item -Path "C:\gmsa\admin.txt" -Destination "C:\inetpub\wwwroot\"
+    Copy-Item -Path "C:\gmsa\gmsa-cred-spec-gmsa-e2e.yml" -Destination "C:\inetpub\wwwroot\gmsa-cred-spec-gmsa-e2e.txt"
+	
+	# Label the DC
+	$hostname = hostname
+	C:\k\kubectl.exe --kubeconfig C:\k\config label nodes $hostname DomainRole=DC
+
+} else {
+    # Add new admin account to needed groups
+    Add-ADGroupMember -Identity "Enterprise Admins" -Members gmsa-admin
+    Add-ADGroupMember -Identity "Domain Admins" -Members gmsa-admin
+    $RunOnce = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce"
+    Set-ItemProperty $RunOnce "gmsa" -Value "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -command $GMSARoot\Setup-gMSA.ps1" -Type String
+    Restart-Computer -Force
+}
+

--- a/extensions/gmsa-dc/v1/supported-orchestrators.json
+++ b/extensions/gmsa-dc/v1/supported-orchestrators.json
@@ -1,0 +1,1 @@
+["Kubernetes"]

--- a/extensions/gmsa-dc/v1/template-link.json
+++ b/extensions/gmsa-dc/v1/template-link.json
@@ -1,0 +1,39 @@
+{
+	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'gmsa-dc')]",
+	"type": "Microsoft.Resources/deployments",
+	"apiVersion": "[variables('apiVersionDeployments')]",
+	"dependsOn": [
+		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
+	],
+	"copy": {
+		"count": "EXTENSION_LOOP_COUNT",
+		"name": "gmsa-dcExtensionLoop"
+	},
+	"properties": {
+		"mode": "Incremental",
+		"templateLink": {
+			"uri": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/extensions/gmsa-dc/v1/template.json",
+			"contentVersion": "1.0.0.0"
+		},
+		"parameters": {
+			"artifactsLocation": {
+				"value": "EXTENSION_URL_REPLACE"
+			},
+			"apiVersionDeployments": {
+				"value": "[variables('apiVersionDeployments')]"
+			},
+			"targetVMName": {
+				"value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"
+			},
+			"targetVMType": {
+            	"value": "EXTENSION_TARGET_VM_TYPE"
+            },
+			"extensionParameters": {
+				"value": "EXTENSION_PARAMETERS_REPLACE"
+			},
+			"vmIndex":{
+				"value": "[copyIndex(EXTENSION_LOOP_OFFSET)]"
+			}
+		}
+	}
+}

--- a/extensions/gmsa-dc/v1/template.json
+++ b/extensions/gmsa-dc/v1/template.json
@@ -1,0 +1,74 @@
+{
+	"$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		 "artifactsLocation": {
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Artifacts Location - URL"
+			 }
+		 },
+		 "apiVersionDeployments": {
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Deployments API Version"
+			 }
+		 },
+		 "targetVMName":{
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Name of the vm to run the extension on"
+			 }
+		 },
+		 "targetVMType":{
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Type of the vm to run the extension: master or agent "
+			}
+		},
+		"extensionParameters": {
+			"type": "securestring",
+			"minLength": 0,
+			"metadata": {
+				"description": "Custom Parameter for Extension - not used in gmsa-dc extension at the moment"
+			}
+		},
+		"vmIndex": {
+			 "type": "int",
+			 "metadata": {
+				 "description": "index in the pool of the current agent, used so that we can get the extension name right"
+			 }
+		 }
+	},
+	"variables": { 
+        "initScriptUrl": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/extensions/gmsa-dc/v1/Promote-DC.ps1"
+	},
+	"resources": [
+	    {
+            "apiVersion": "[parameters('apiVersionDeployments')]",
+            "dependsOn": [],
+            "location": "[resourceGroup().location]",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('targetVMName'),'/cse', '-', parameters('targetVMType'), '-', parameters('vmIndex'))]", 
+            "properties": {
+                "publisher": "Microsoft.Compute",
+                "type": "CustomScriptExtension",
+                "typeHandlerVersion": "1.8",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "fileUris": [
+                        "[variables('initScriptUrl')]"
+                    ]
+                },
+                "protectedSettings": {
+                "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted ./Promote-DC.ps1')]"
+                }
+            }
+        }
+	],
+	"outputs": {  }
+ }

--- a/extensions/gmsa-member/README.md
+++ b/extensions/gmsa-member/README.md
@@ -1,0 +1,70 @@
+# gMSA-Member Extension
+
+This extension will join a worker node to the Active Directory Domain created by the gmsa-dc extension.  This should be used 
+in conjunction with the gmsa-dc extension.
+
+Add this extension to your regular Windows worker pool.
+
+# Configuration
+
+|Name               |Required|Acceptable Value     |
+|-------------------|--------|---------------------|
+|name               |yes     |gmsa-member          |
+|version            |yes     |v1                   |
+|rootURL            |optional|                     |
+
+# Example
+
+```
+    ...
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 2
+		...
+		"extensions": [
+          {
+            "name": "gmsa-member",
+			"singleOrAll": "all"
+          }
+        ]
+      }
+      },
+	  {
+        "name": "windowsgmsa",
+		"count": 1
+        "extensions": [
+          {
+            "name": "gmsa-dc"
+          }
+        ]
+      }
+    ],
+    ...
+    "extensionProfiles": [
+      {
+        "name": "gmsa-member",
+        "version": "v1"
+      }
+    ]
+    ...
+```
+
+
+# Supported Orchestrators
+
+Kubernetes
+
+# Troubleshoot
+
+Extension execution output is logged to files found under the following directory on the target virtual machine.
+
+```sh
+C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension
+```
+
+The specified files are downloaded into the following directory on the target virtual machine.
+
+```sh
+C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\1.*\Downloads\<n>
+```

--- a/extensions/gmsa-member/v1/Join-Domain.ps1
+++ b/extensions/gmsa-member/v1/Join-Domain.ps1
@@ -1,0 +1,99 @@
+<#
+ .SYNOPSIS
+ This script will join the local computer to the domain for gmsa testing
+
+ .NOTES
+ This is only for automated e2e testing.  DO NOT use this for production.
+ Jeremy Wood (JeremyWx)
+ Version: 1.0.0.0
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Set script variables
+$GMSARoot = "C:\gmsa"
+
+Start-Transcript -Path "$GMSARoot\join.txt"
+
+# Create a working directory and change to it
+if (( Test-Path -Path "$GMSARoot") -eq $false ) {
+    mkdir $GMSARoot
+    Set-Location -Path $GMSARoot
+} 
+
+# Function to find the Domain Controller
+function FindDC() {
+    Try {
+        $DCIP = C:\k\kubectl.exe get node --kubeconfig=C:\k\config --selector="DomainRole=DC" -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}"
+        if ($null -eq $DCIP) {
+            return 11
+        } else {
+            Write-Host "DC IP Address is $DCIP"
+            return $DCIP
+        }        
+    } catch {
+        Start-Sleep 10
+        return 11
+    }
+}
+
+function ChangeDNS($DCIP) {
+    Try {
+        if ($null -eq $DCIP) {
+            $DCIP = FindDC
+        }
+        Write-Host "Changing DNS to $DCIP"
+        $Adapter = Get-NetAdapter | Where-Object {$_.Name -like "vEthernet (Ether*"}
+        Set-DnsClientServerAddress -InterfaceIndex ($Adapter).ifIndex -ServerAddresses $DCIP
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function JoinDomain($GMSARoot) {
+    Write-Host "Join to domain"
+    $adminpass = Get-Content -Path "$GMSARoot\admin.txt"
+    $joinCred = New-Object pscredential -ArgumentList ([pscustomobject]@{
+        UserName = "k8sgmsa\gmsa-admin"
+        Password = (ConvertTo-SecureString -String ($adminpass -replace "`n|`r") -AsPlainText -Force)[0]
+    })
+    Try {
+        Add-Computer -Domain "k8sgmsa.lan" -Credential $joinCred
+        return $true
+    } catch {
+        Start-Sleep 10
+        return $false
+    }
+
+}
+
+function CopyFiles($DCIP) {
+    Write-Host "Copy Files from $DCIP"
+    Try {
+        Invoke-WebRequest -UseBasicParsing http://$DCIP/admin.txt -OutFile "$GMSARoot\admin.txt"
+        Invoke-WebRequest -UseBasicParsing http://$DCIP/gmsa-cred-spec-gmsa-e2e.txt -OutFile "$GMSARoot\gmsa-cred-spec-gmsa-e2e.yml"
+        return $true
+    } catch {
+        Start-Sleep 5
+        return $false
+    }
+}
+
+# Find the DC and get its IP
+Do { $DCIP = FindDC } while ( $DCIP -eq 11 -or $null -eq $DCIP)
+$DCIP = FindDC
+
+# Set NIC to look at DC for DNS
+Do { $DNSResult = ChangeDNS } while ( $DNSResult -eq $false )
+
+# Obtain the password to join the domain
+Do { $CopyResult = CopyFiles($DCIP)} while ( $CopyResult -eq $false )
+
+# Join the domain
+Do { $JDResult = JoinDomain($GMSARoot) } while ( $JDResult -eq $false )
+
+# Reboot to finish the join
+Restart-Computer -Force

--- a/extensions/gmsa-member/v1/supported-orchestrators.json
+++ b/extensions/gmsa-member/v1/supported-orchestrators.json
@@ -1,0 +1,1 @@
+["Kubernetes"]

--- a/extensions/gmsa-member/v1/template-link.json
+++ b/extensions/gmsa-member/v1/template-link.json
@@ -1,0 +1,39 @@
+{
+	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'gmsa-member')]",
+	"type": "Microsoft.Resources/deployments",
+	"apiVersion": "[variables('apiVersionDeployments')]",
+	"dependsOn": [
+		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
+	],
+	"copy": {
+		"count": "EXTENSION_LOOP_COUNT",
+		"name": "gmsa-memberExtensionLoop"
+	},
+	"properties": {
+		"mode": "Incremental",
+		"templateLink": {
+			"uri": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/extensions/gmsa-member/v1/template.json",
+			"contentVersion": "1.0.0.0"
+		},
+		"parameters": {
+			"artifactsLocation": {
+				"value": "EXTENSION_URL_REPLACE"
+			},
+			"apiVersionDeployments": {
+				"value": "[variables('apiVersionDeployments')]"
+			},
+			"targetVMName": {
+				"value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"
+			},
+			"targetVMType": {
+            	"value": "EXTENSION_TARGET_VM_TYPE"
+            },
+			"extensionParameters": {
+				"value": "EXTENSION_PARAMETERS_REPLACE"
+			},
+			"vmIndex":{
+				"value": "[copyIndex(EXTENSION_LOOP_OFFSET)]"
+			}
+		}
+	}
+}

--- a/extensions/gmsa-member/v1/template.json
+++ b/extensions/gmsa-member/v1/template.json
@@ -1,0 +1,74 @@
+{
+	"$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		 "artifactsLocation": {
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Artifacts Location - URL"
+			 }
+		 },
+		 "apiVersionDeployments": {
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Deployments API Version"
+			 }
+		 },
+		 "targetVMName":{
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Name of the vm to run the extension on"
+			 }
+		 },
+		 "targetVMType":{
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Type of the vm to run the extension: master or agent "
+			}
+		},
+		"extensionParameters": {
+			"type": "securestring",
+			"minLength": 0,
+			"metadata": {
+				"description": "Custom Parameter for Extension - not used in gmsa-member extension at the moment"
+			}
+		},
+		"vmIndex": {
+			 "type": "int",
+			 "metadata": {
+				 "description": "index in the pool of the current agent, used so that we can get the extension name right"
+			 }
+		 }
+	},
+	"variables": { 
+        "initScriptUrl": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/extensions/gmsa-member/v1/Join-Domain.ps1"
+	},
+	"resources": [
+	    {
+            "apiVersion": "[parameters('apiVersionDeployments')]",
+            "dependsOn": [],
+            "location": "[resourceGroup().location]",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('targetVMName'),'/cse', '-', parameters('targetVMType'), '-', parameters('vmIndex'))]", 
+            "properties": {
+                "publisher": "Microsoft.Compute",
+                "type": "CustomScriptExtension",
+                "typeHandlerVersion": "1.8",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "fileUris": [
+                        "[variables('initScriptUrl')]"
+                    ]
+                },
+                "protectedSettings": {
+                "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted ./Join-Domain.ps1')]"
+                }
+            }
+        }
+	],
+	"outputs": {  }
+ }


### PR DESCRIPTION
**Reason for Change**:

Enables automated testing of GMSA feature.

**Notes**:
This extension enables automated e2e testing of the GMSA feature usable by Windows nodes.  It is recommended to run this extension against a pool of one server.  The extension will create the Active Directory domain, the Domain Controller, and the Group Managed Service Account for testing.

This PR was moved to this repo from AKS.
