### PR TITLE
Update coredns config for gmsa

### DIFF
--- a/extensions/gmsa-coredns/README.md
+++ b/extensions/gmsa-coredns/README.md
@@ -1,0 +1,58 @@
+# gMSA-coredns Extension
+
+This extension will modify the local coredns config to allow resources to locate the Active Directory domain and members created by 
+the gmsa-dc and gmsa-member extensions.
+
+This extension will need to be run against the master.
+
+# Configuration
+
+|Name               |Required|Acceptable Value     |
+|-------------------|--------|---------------------|
+|name               |yes     |gmsa-coredns         |
+|version            |yes     |v1                   |
+|rootURL            |optional|                     |
+
+# Example
+
+```
+    ...
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "ubuntu",
+      "extensions": [
+          {
+              "name": "master_extension"
+          },
+          {
+              "name": "gmsa-coredns"
+          }
+      ]
+    },
+    ...
+    "extensionProfiles": [
+        {
+          "name":                "gmsa-coredns",
+          "version":             "v1",
+          "extensionParameters": "parameters",
+          "rootURL":             "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+          "script":              "update-coredns.sh"
+        }
+    ]
+    ...
+```
+
+
+# Supported Orchestrators
+
+Kubernetes
+
+# Troubleshoot
+
+Extension execution output is logged to files found under the following directory on the target virtual machine.
+
+```
+/var/log/azure/update-coredns.log
+```

--- a/extensions/gmsa-coredns/v1/supported-orchestrators.json
+++ b/extensions/gmsa-coredns/v1/supported-orchestrators.json
@@ -1,0 +1,1 @@
+["Kubernetes"]

--- a/extensions/gmsa-coredns/v1/template-link.json
+++ b/extensions/gmsa-coredns/v1/template-link.json
@@ -1,0 +1,39 @@
+{
+    "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'gmsa-coredns')]",
+    "type": "Microsoft.Resources/deployments",
+    "apiVersion": "[variables('apiVersionDeployments')]",
+    "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
+    ],
+    "copy": {
+        "count": "EXTENSION_LOOP_COUNT",
+        "name": "gmsa-corednsextensionloop"
+    },
+    "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "EXTENSION_URL_REPLACEextensions/gmsa-coredns/v1/template.json",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "artifactsLocation": {
+                "value": "EXTENSION_URL_REPLACE"
+            },
+            "apiVersionDeployments": {
+                "value": "[variables('apiVersionDeployments')]"
+            },
+            "targetVMName": {
+                "value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"
+            },
+            "targetVMType": {
+                "value": "EXTENSION_TARGET_VM_TYPE"
+            },
+            "extensionParameters": {
+                "value": "EXTENSION_PARAMETERS_REPLACE"
+            },
+            "vmIndex":{
+                "value": "[copyIndex(EXTENSION_LOOP_OFFSET)]"
+            }
+        }
+    }
+}

--- a/extensions/gmsa-coredns/v1/template.json
+++ b/extensions/gmsa-coredns/v1/template.json
@@ -1,0 +1,75 @@
+{
+   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {  
+		"artifactsLocation": {
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Artifacts Location - URL"
+			}
+        },
+		"apiVersionDeployments": {
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Deployments API Version"
+			}
+		},
+		"targetVMName":{
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Name of the vm to run the "
+			}
+		},
+		"targetVMType":{
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Type of the vm to run the extension: master or agent "
+			}
+		},
+		"extensionParameters": {
+			"type": "securestring",
+			"minLength": 0,
+			"metadata": {
+				"description": "Custom Parameter for Extension - for gmsa-coredns, this is empty"
+			}
+		},
+		"vmIndex": {
+			"type": "int",
+			"metadata": {
+				"description": "index in the pool of the current agent, used so that we can get the extension name right"
+			}
+		}
+   },
+   "variables": {  
+		"singleQuote": "'",
+		"initScriptUrl": "[concat(parameters('artifactsLocation'), 'extensions/gmsa-coredns/v1/update-coredns.sh')]"
+   },
+   "resources": [  
+	{
+      "apiVersion": "[parameters('apiVersionDeployments')]",
+      "dependsOn": [],
+      "location": "[resourceGroup().location]",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+	  "name": "[concat(parameters('targetVMName'),'/cse', '-', parameters('targetVMType'), '-', parameters('vmIndex'))]", 
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+			"fileUris": [ 
+			   "[variables('initScriptUrl')]" 
+			 ]
+		},
+        "protectedSettings": {
+			"commandToExecute": "[concat('/bin/bash -c \"/bin/bash ./update-coredns.sh ', variables('singleQuote'), parameters('extensionParameters'), variables('singleQuote'), ' >> /var/log/azure/update-coredns.log 2>&1 &\" &')]"
+        }
+      }
+    }
+	],
+   "outputs": {  }
+}

--- a/extensions/gmsa-coredns/v1/update-coredns.sh
+++ b/extensions/gmsa-coredns/v1/update-coredns.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Get the IP of the DC as soon as it is available
+while [$DCIP = $null]
+do
+    DCIP=$(kubectl get node --selector="agentpool=windowsgmsa" -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}") > /dev/null 2>&1
+    sleep 5
+done
+
+cat << EOF >> coredns-custom.sed
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  Corefile: |
+    k8sgmsa.lan:53 {
+      errors
+      cache 30
+      log
+      forward . DCIP
+    }
+EOF
+
+# Place the IP for the DC into the config file
+sed "s/DCIP/${DCIP}/g" coredns-custom.sed > coredns-custom.yml
+
+# Apply the config file
+kubectl apply -f coredns-custom.yml
+
+# Restart the CoreDNS pods to pick up the changes
+kubectl -n kube-system rollout restart deployment coredns


### PR DESCRIPTION
This extension for AKS updates the coredns config on the master node so that resources can find the Active Directory Domain, Domain Controller, and members.

This work in conjunction with the gmsa-dc and gmsa-member extensions in order to facilitate automated e2e testing for the gmsa feature.