### PR TITLE
Removing WindowsRunAsUserName feature gate in kubernetes_release_staging job

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -11,8 +11,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
 	"apiServerConfig": {
-          "--runtime-config":  "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
-	  "--feature-gates": "WindowsRunAsUserName=true"
+          "--runtime-config":  "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },
@@ -93,7 +92,7 @@
       "secret": ""
     },
     "extensionProfiles": [
-       {
+        {
           "name":    "agent_preprovision_extension",
           "version": "v1",
           "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",


### PR DESCRIPTION
Removing WindowsRunAsUserName feature gate because it is moved to beta for 1.17

This PR should be held until after these PRs are merged:
- https://github.com/kubernetes/kubernetes/pull/84882
- https://github.com/kubernetes/test-infra/pull/15173 
