### PR TITLE
Import gce-k8s-windows-testing repository

### DIFF
--- a/gce/0001-Build-windows-biniaries-when-running-make-quick-rele.patch
+++ b/gce/0001-Build-windows-biniaries-when-running-make-quick-rele.patch
@@ -1,0 +1,40 @@
+From 610337a079eaee8560d1ae8d4ad613730c28e3d9 Mon Sep 17 00:00:00 2001
+From: Yu-Ju Hong <yjhong@google.com>
+Date: Thu, 10 Jan 2019 15:06:01 -0800
+Subject: [PATCH] Build windows biniaries when running `make quick-release`
+
+---
+ hack/lib/golang.sh | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/hack/lib/golang.sh b/hack/lib/golang.sh
+index 41004ced12..b825df1725 100755
+--- a/hack/lib/golang.sh
++++ b/hack/lib/golang.sh
+@@ -98,7 +98,10 @@ if [[ -n "${KUBE_BUILD_PLATFORMS:-}" ]]; then
+   readonly KUBE_CLIENT_PLATFORMS
+ elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
+   readonly KUBE_SERVER_PLATFORMS=(linux/amd64)
+-  readonly KUBE_NODE_PLATFORMS=(linux/amd64)
++  readonly KUBE_NODE_PLATFORMS=(
++    linux/amd64
++    windows/amd64
++  )
+   if [[ "${KUBE_BUILDER_OS:-}" == "darwin"* ]]; then
+     readonly KUBE_TEST_PLATFORMS=(
+       darwin/amd64
+@@ -110,7 +113,10 @@ elif [[ "${KUBE_FASTBUILD:-}" == "true" ]]; then
+     )
+   else
+     readonly KUBE_TEST_PLATFORMS=(linux/amd64)
+-    readonly KUBE_CLIENT_PLATFORMS=(linux/amd64)
++    readonly KUBE_CLIENT_PLATFORMS=(
++      linux/amd64
++      windows/amd64
++    )
+   fi
+ else
+ 
+-- 
+2.21.0.rc0.258.g878e2cd30e-goog
+

--- a/gce/LICENSE
+++ b/gce/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gce/OWNERS
+++ b/gce/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - pjh
+  - yliaog

--- a/gce/README.md
+++ b/gce/README.md
@@ -1,0 +1,19 @@
+# Windows Kubernetes testing on Google Compute Engine
+
+This directory contains scripts and data used for running Windows Kubernetes
+tests on GCE.
+
+Continuous test results can be seen on the
+[sig-windows](https://testgrid.k8s.io/sig-windows#gce-windows-master) and
+[google-windows](https://testgrid.k8s.io/google-windows) testgrids. The
+configuration for those tests lives in
+[test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-windows/windows-gce.yaml).
+
+This code previously lived at
+[gce-k8s-windows-testing](https://github.com/yujuhong/gce-k8s-windows-testing).
+
+## Bringing up a Windows Kubernetes cluster on Google Compute Engine
+
+See the
+[README](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/windows/README-GCE-Windows-kube-up.md)
+in the main kubernetes repository.

--- a/gce/prepull.yaml
+++ b/gce/prepull.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull
+spec:
+  selector:
+    matchLabels:
+      prepull-test-images: e2e
+  template:
+    metadata:
+      labels:
+        prepull-test-images: e2e
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      initContainers:
+      - image: e2eteam/busybox:1.29
+        name: busybox1
+        command: ["cmd", "exit"]
+      - image: e2eteam/curl:1803
+        name: curl2
+        command: ["cmd", "exit"]
+      - image: e2eteam/java:openjdk-8-jre
+        name: java3
+        command: ["cmd", "exit"]
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
+        command: ["cmd", "exit"]
+      - image: e2eteam/cassandra:v13
+        name: cassandra5
+        command: ["cmd", "exit"]
+      - image: e2eteam/dnsutils:1.1
+        name: dnsutils6
+        command: ["cmd", "exit"]
+      - image: e2eteam/echoserver:2.2
+        name: echoserver7
+        command: ["cmd", "exit"]
+      - image: e2eteam/entrypoint-tester:1.0
+        name: entrypoint-tester8
+        command: ["cmd", "exit"]
+      - image: e2eteam/etcd:v3.3.10
+        name: etcd9
+        command: ["cmd", "exit"]
+      - image: e2eteam/etcd:3.3.10
+        name: etcd10
+        command: ["cmd", "exit"]
+      - image: e2eteam/fakegitserver:1.0
+        name: fakegitserver11
+        command: ["cmd", "exit"]
+      - image: e2eteam/gb-frontend:v6
+        name: gb-frontend12
+        command: ["cmd", "exit"]
+      - image: e2eteam/gb-redisslave:v3
+        name: gb-redisslave13
+        command: ["cmd", "exit"]
+      - image: e2eteam/hazelcast-kubernetes:3.8_1
+        name: hazelcast-kubernetes14
+        command: ["cmd", "exit"]
+      - image: e2eteam/hostexec:1.1
+        name: hostexec15
+        command: ["cmd", "exit"]
+      - image: e2eteam/iperf:1.0
+        name: iperf16
+        command: ["cmd", "exit"]
+      - image: e2eteam/jessie-dnsutils:1.0
+        name: jessie-dnsutils17
+        command: ["cmd", "exit"]
+      - image: e2eteam/kitten:1.0
+        name: kitten18
+        command: ["cmd", "exit"]
+      - image: e2eteam/liveness:1.1
+        name: liveness19
+        command: ["cmd", "exit"]
+      - image: e2eteam/logs-generator:1.0
+        name: logs-generator20
+        command: ["cmd", "exit"]
+      - image: e2eteam/mounttest:1.0
+        name: mounttest21
+        command: ["cmd", "exit"]
+      - image: e2eteam/nautilus:1.0
+        name: nautilus22
+        command: ["cmd", "exit"]
+      - image: e2eteam/net:1.0
+        name: net23
+        command: ["cmd", "exit"]
+      - image: e2eteam/netexec:1.1
+        name: netexec24
+        command: ["cmd", "exit"]
+      - image: e2eteam/nettest:1.0
+        name: nettest25
+        command: ["cmd", "exit"]
+      - image: e2eteam/nginx:1.14-alpine
+        name: nginx26
+        command: ["cmd", "exit"]
+      - image: e2eteam/nginx:1.15-alpine
+        name: nginx27
+        command: ["cmd", "exit"]
+      - image: e2eteam/no-snat-test:1.0
+        name: no-snat-test28
+        command: ["cmd", "exit"]
+      - image: e2eteam/pause:3.1
+        name: pause29
+        command: ["cmd", "exit"]
+      - image: e2eteam/port-forward-tester:1.0
+        name: port-forward-tester30
+        command: ["cmd", "exit"]
+      - image: e2eteam/porter:1.0
+        name: porter31
+        command: ["cmd", "exit"]
+      - image: e2eteam/redis:1.0
+        name: redis32
+        command: ["cmd", "exit"]
+      - image: e2eteam/resource-consumer:1.4
+        name: resource-consumer33-1
+        command: ["cmd", "exit"]
+      - image: e2eteam/resource-consumer:1.5
+        name: resource-consumer33-2
+        command: ["cmd", "exit"]
+      - image: e2eteam/resource-consumer-controller:1.0
+        name: resource-consumer-controller34
+        command: ["cmd", "exit"]
+      - image: e2eteam/rethinkdb:1.16.0_1
+        name: rethinkdb35
+        command: ["cmd", "exit"]
+      - image: e2eteam/sample-apiserver:1.10
+        name: sample-apiserver36
+        command: ["cmd", "exit"]
+      - image: e2eteam/serve-hostname:1.1
+        name: serve-hostname37
+        command: ["cmd", "exit"]
+      - image: e2eteam/webhook:1.13v1
+        name: webhook38
+        command: ["cmd", "exit"]
+      containers:
+      - image: mcr.microsoft.com/k8s/core/pause:1.0.0
+        name: pause

--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# When running in prow, the working directory is the root of the test-infra
+# repository.
+
+# Taint the Linux nodes to prevent the test workloads from landing on them.
+# TODO: remove this once the issue is resolved:
+# https://github.com/kubernetes/kubernetes/issues/69892
+LINUX_NODES=$(kubectl get nodes -l beta.kubernetes.io/os=linux -o name)
+LINUX_NODE_COUNT=$(echo ${LINUX_NODES} | wc -w)
+for node in $LINUX_NODES; do
+  kubectl taint node $node node-under-test=false:NoSchedule
+done
+
+# Untaint the windows nodes to allow test workloads without tolerations to be
+# scheduled onto them.
+WINDOWS_NODES=$(kubectl get nodes -l beta.kubernetes.io/os=windows -o name)
+for node in $WINDOWS_NODES; do
+  kubectl taint node $node node.kubernetes.io/os:NoSchedule-
+done
+
+# Pre-pull all the test images. The images are currently hard-coded.
+# Eventually, we should get the list directly from
+# https://github.com/kubernetes-sigs/windows-testing/blob/master/images/PullImages.ps1
+SCRIPT_ROOT=$(cd `dirname $0` && pwd)
+kubectl create -f ${SCRIPT_ROOT}/prepull.yaml
+# Wait 10 minutes for the test images to be pulled onto the nodes.
+sleep ${PREPULL_TIMEOUT:-15m}
+# Check the status of the pods.
+kubectl get pods -o wide
+# Delete the pods anyway since pre-pulling is best-effort
+kubectl delete -f ${SCRIPT_ROOT}/prepull.yaml
+# Wait a few more minutes for the pod to be cleaned up.
+sleep 3m
+
+# Download and set the list of test image repositories to use.
+curl \
+  https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list \
+  -o ${WORKSPACE}/repo-list.yaml
+export KUBE_TEST_REPO_LIST=${WORKSPACE}/repo-list.yaml
+
+# When using customized test command (which we are now), report-dir is not set
+# by default, so set it here.
+# The test framework will not proceed to run tests unless all nodes are ready
+# AND schedulable. Allow not-ready nodes since we make Linux nodes
+# unschedulable.
+# Do not set --disable-log-dump because upstream cannot handle dumping logs
+# from windows nodes yet.
+./hack/ginkgo-e2e.sh $@ --report-dir=${ARTIFACTS} --allowed-not-ready-nodes=${LINUX_NODE_COUNT}


### PR DESCRIPTION
Our Windows-on-GCE test jobs still depend on https://github.com/yujuhong/gce-k8s-windows-testing, which predates this repository. This PR migrates that repository here and adds a new OWNERS and README file.

The benefits are discoverability and perhaps consistency between Windows test environments (e.g. when the manifest of test containers for AKS is updated we can update the GCE manifest as well).

cc @yliaog @YangLu1031