### PR TITLE
Update prepulled Windows test containers

### DIFF
--- a/gce/prepull-1.14.yaml
+++ b/gce/prepull-1.14.yaml
@@ -1,0 +1,257 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-test-containers
+spec:
+  selector:
+    matchLabels:
+      prepull-test-images: e2e
+  template:
+    metadata:
+      labels:
+        prepull-test-images: e2e
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      # To generate this list from the build-log.txt output of an e2e test
+      # result:
+      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #   build-log.txt | sort | uniq
+      # DaemonSets do not support a RestartPolicy other than 'Always', so we
+      # run ping in each container to keep it alive so that kubernetes does not
+      # continually restart the containers while we're prepulling.
+      containers:
+      - image: e2eteam/busybox:1.29
+        name: busybox1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/curl:1803
+        name: curl2
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/java:openjdk-8-jre
+        name: java3
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/cassandra:v13
+        name: cassandra5
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/dnsutils:1.1
+        name: dnsutils6
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/echoserver:2.2
+        name: echoserver7
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/entrypoint-tester:1.0
+        name: entrypoint-tester8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:v3.3.10
+        name: etcd9
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:3.3.10
+        name: etcd10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/fakegitserver:1.0
+        name: fakegitserver11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-frontend:v6
+        name: gb-frontend12
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-redisslave:v3
+        name: gb-redisslave13
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/hazelcast-kubernetes:3.8_1
+        name: hazelcast-kubernetes14
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/hostexec:1.1
+        name: hostexec15
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/iperf:1.0
+        name: iperf16
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/jessie-dnsutils:1.0
+        name: jessie-dnsutils17
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/kitten:1.0
+        name: kitten18
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/liveness:1.1
+        name: liveness19
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/logs-generator:1.0
+        name: logs-generator20
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/mounttest:1.0
+        name: mounttest21
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nautilus:1.0
+        name: nautilus22
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/net:1.0
+        name: net23
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/netexec:1.1
+        name: netexec24
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nettest:1.0
+        name: nettest25
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.14-alpine
+        name: nginx26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.15-alpine
+        name: nginx27
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/no-snat-test:1.0
+        name: no-snat-test28
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/pause:3.1
+        name: pause29
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/port-forward-tester:1.0
+        name: port-forward-tester30
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/porter:1.0
+        name: porter31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/redis:1.0
+        name: redis32
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/resource-consumer:1.4
+        name: resource-consumer33-1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/resource-consumer:1.5
+        name: resource-consumer33-2
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/resource-consumer-controller:1.0
+        name: resource-consumer-controller34
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/rethinkdb:1.16.0_1
+        name: rethinkdb35
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/sample-apiserver:1.10
+        name: sample-apiserver36
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/serve-hostname:1.1
+        name: serve-hostname37
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/webhook:1.13v1
+        name: webhook38
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']

--- a/gce/prepull-1.15.yaml
+++ b/gce/prepull-1.15.yaml
@@ -1,0 +1,239 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-test-containers
+spec:
+  selector:
+    matchLabels:
+      prepull-test-images: e2e
+  template:
+    metadata:
+      labels:
+        prepull-test-images: e2e
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      # To generate this list from the build-log.txt output of an e2e test
+      # result:
+      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #   build-log.txt | sort | uniq
+      # DaemonSets do not support a RestartPolicy other than 'Always', so we
+      # run ping in each container to keep it alive so that kubernetes does not
+      # continually restart the containers while we're prepulling.
+      containers:
+      - image: e2eteam/busybox:1.29
+        name: busybox1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/cassandra:v13
+        name: cassandra5
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/curl:1803
+        name: curl2
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/dnsutils:1.1
+        name: dnsutils6
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/echoserver:2.2
+        name: echoserver7
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/entrypoint-tester:1.0
+        name: entrypoint-tester8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:3.3.10
+        name: etcd9
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:v3.3.10
+        name: etcd10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/fakegitserver:1.0
+        name: fakegitserver11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-frontend:v6
+        name: gb-frontend12
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-redisslave:v3
+        name: gb-redisslave13
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/hazelcast-kubernetes:3.8_1
+        name: hazelcast-kubernetes14
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/hostexec:1.1
+        name: hostexec15
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/iperf:1.0
+        name: iperf16
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/java:openjdk-8-jre
+        name: java-openjdk-8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/jessie-dnsutils:1.0
+        name: jessie-dnsutils17
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/kitten:1.0
+        name: kitten18
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/liveness:1.1
+        name: liveness19
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/logs-generator:1.0
+        name: logs-generator-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/mounttest:1.0
+        name: mounttest21
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nautilus:1.0
+        name: nautilus22
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/net:1.0
+        name: net-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/netexec:1.1
+        name: netexec-11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nettest:1.0
+        name: nettest-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.14-alpine
+        name: nginx26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.15-alpine
+        name: nginx-115
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/no-snat-test:1.0
+        name: no-snat-test-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/pause:3.1
+        name: pause-3-1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/porter:1.0
+        name: porter-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/port-forward-tester:1.0
+        name: port-forward-tester-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/redis:1.0
+        name: redis-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/resource-consumer:1.4
+        name: resource-consumer-14
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/resource-consumer:1.5
+        name: resource-consumer-15
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/sample-apiserver:1.10
+        name: sample-apiserver-110
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/serve-hostname:1.1
+        name: serve-hostname-11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']

--- a/gce/prepull-1.16.yaml
+++ b/gce/prepull-1.16.yaml
@@ -1,0 +1,191 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-test-containers
+spec:
+  selector:
+    matchLabels:
+      prepull-test-images: e2e
+  template:
+    metadata:
+      labels:
+        prepull-test-images: e2e
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      # To generate this list from the build-log.txt output of an e2e test
+      # result:
+      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #   build-log.txt | sort | uniq
+      # DaemonSets do not support a RestartPolicy other than 'Always', so we
+      # run ping in each container to keep it alive so that kubernetes does not
+      # continually restart the containers while we're prepulling.
+      containers:
+      - image: e2eteam/agnhost:2.6
+        name: agnhost-26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/busybox:1.29
+        name: busybox1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/cassandra:v13
+        name: cassandra5
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/curl:1803
+        name: curl2
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/dnsutils:1.1
+        name: dnsutils6
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/echoserver:2.2
+        name: echoserver7
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/entrypoint-tester:1.0
+        name: entrypoint-tester8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:3.3.10
+        name: etcd9
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:v3.3.10
+        name: etcd10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/fakegitserver:1.0
+        name: fakegitserver11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-frontend:v6
+        name: gb-frontend12
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-redisslave:v3
+        name: gb-redisslave13
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/hazelcast-kubernetes:3.8_1
+        name: hazelcast-kubernetes14
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/hostexec:1.1
+        name: hostexec15
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/httpd:2.4.38-alpine
+        name: httpd-2438
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/httpd:2.4.39-alpine
+        name: httpd-2439
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/iperf:1.0
+        name: iperf16
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/java:openjdk-8-jre
+        name: java-openjdk-8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/jessie-dnsutils:1.0
+        name: jessie-dnsutils17
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/kitten:1.0
+        name: kitten18
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/liveness:1.1
+        name: liveness19
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/logs-generator:1.0
+        name: logs-generator-10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/mounttest:1.0
+        name: mounttest21
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nautilus:1.0
+        name: nautilus22
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.14-alpine
+        name: nginx26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/pause:3.1
+        name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/redis:5.0.5-alpine
+        name: redis-505
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']

--- a/gce/prepull-1.17.yaml
+++ b/gce/prepull-1.17.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-test-containers
+spec:
+  selector:
+    matchLabels:
+      prepull-test-images: e2e
+  template:
+    metadata:
+      labels:
+        prepull-test-images: e2e
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      # To generate this list from the build-log.txt output of an e2e test
+      # result:
+      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #   build-log.txt | sort | uniq
+      # DaemonSets do not support a RestartPolicy other than 'Always', so we
+      # run ping in each container to keep it alive so that kubernetes does not
+      # continually restart the containers while we're prepulling.
+      containers:
+      - image: e2eteam/agnhost:2.8
+        name: agnhost-28
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/busybox:1.29
+        name: busybox1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/cassandra:v13
+        name: cassandra5
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/curl:1803
+        name: curl2
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/dnsutils:1.1
+        name: dnsutils6
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/echoserver:2.2
+        name: echoserver7
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/entrypoint-tester:1.0
+        name: entrypoint-tester8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:3.3.10
+        name: etcd9
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:v3.3.10
+        name: etcd10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/fakegitserver:1.0
+        name: fakegitserver11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-frontend:v6
+        name: gb-frontend12
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/httpd:2.4.38-alpine
+        name: httpd-2438
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/httpd:2.4.39-alpine
+        name: httpd-2439
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/java:openjdk-8-jre
+        name: java-openjdk-8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/jessie-dnsutils:1.0
+        name: jessie-dnsutils17
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/kitten:1.0
+        name: kitten18
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/mounttest:1.0
+        name: mounttest21
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nautilus:1.0
+        name: nautilus22
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.14-alpine
+        name: nginx26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/pause:3.1
+        name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']

--- a/gce/prepull-1.18.yaml
+++ b/gce/prepull-1.18.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prepull-test-containers
+spec:
+  selector:
+    matchLabels:
+      prepull-test-images: e2e
+  template:
+    metadata:
+      labels:
+        prepull-test-images: e2e
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      # To generate this list from the build-log.txt output of an e2e test
+      # result:
+      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #   build-log.txt | sort | uniq
+      # DaemonSets do not support a RestartPolicy other than 'Always', so we
+      # run ping in each container to keep it alive so that kubernetes does not
+      # continually restart the containers while we're prepulling.
+      containers:
+      - image: e2eteam/agnhost:2.8
+        name: agnhost-28
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/busybox:1.29
+        name: busybox1
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/cassandra:v13
+        name: cassandra5
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/curl:1803
+        name: curl2
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/dnsutils:1.1
+        name: dnsutils6
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/echoserver:2.2
+        name: echoserver7
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/entrypoint-tester:1.0
+        name: entrypoint-tester8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:3.3.10
+        name: etcd9
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:3.4.3
+        name: etcd-343
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/etcd:v3.3.10
+        name: etcd10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/fakegitserver:1.0
+        name: fakegitserver11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-frontend:v6
+        name: gb-frontend12
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/httpd:2.4.38-alpine
+        name: httpd-2438
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/httpd:2.4.39-alpine
+        name: httpd-2439
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/java:openjdk-8-jre
+        name: java-openjdk-8
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/jessie-dnsutils:1.0
+        name: jessie-dnsutils17
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/kitten:1.0
+        name: kitten18
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/mounttest:1.0
+        name: mounttest21
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nautilus:1.0
+        name: nautilus22
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/nginx:1.14-alpine
+        name: nginx26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/pause:3.1
+        name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/sample-apiserver:1.17
+        name: sample-apiserver-117
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']

--- a/gce/prepull-head.yaml
+++ b/gce/prepull-head.yaml
@@ -1,0 +1,1 @@
+prepull-1.18.yaml

--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -25,15 +25,18 @@ done
 
 # Pre-pull all the test images. The images are currently hard-coded.
 # Eventually, we should get the list directly from
-# https://github.com/kubernetes-sigs/windows-testing/blob/master/images/PullImages.ps1
+# https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go.
+PREPULL_FILE=${PREPULL_YAML:-prepull-head.yaml}
 SCRIPT_ROOT=$(cd `dirname $0` && pwd)
-kubectl create -f ${SCRIPT_ROOT}/prepull.yaml
-# Wait 10 minutes for the test images to be pulled onto the nodes.
-sleep ${PREPULL_TIMEOUT:-15m}
+kubectl create -f ${SCRIPT_ROOT}/${PREPULL_FILE}
+# Wait a while for the test images to be pulled onto the nodes. In empirical
+# testing it could take up to 30 minutes to finish pulling all the test
+# containers on a node.
+sleep ${PREPULL_TIMEOUT:-30m}
 # Check the status of the pods.
 kubectl get pods -o wide
 # Delete the pods anyway since pre-pulling is best-effort
-kubectl delete -f ${SCRIPT_ROOT}/prepull.yaml
+kubectl delete -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a few more minutes for the pod to be cleaned up.
 sleep 3m
 


### PR DESCRIPTION
Some of our Windows GCE test jobs have been timing out more frequently and I noticed that the list of containers that we prepull onto the nodes has not been updated in a while. This PR makes the following changes:
  - Forks the prepull.yaml file into version-specific files. The containers used for each version were determined by examining the build.txt output files from current test jobs.
  - Updates run-e2e.sh to use an environment variable to select which prepull manifest to use. I'll follow up with a test-infra PR to set this variable for each of our test jobs.
  - Switches from initContainers to just containers in the DaemonSet. initContainers will halt if any container fails to pull + start. Replaces the container run commands with a command that will infinitely loop rather than exiting, so that kubernetes won't keep trying to restart stopped containers while we're prepulling.
  - Increases the duration of the container prepull phase from 15 minutes to 30 minutes, based on initial findings from n1-standard-2 test VMs in GCE. If this causes entire test runs to timeout then I'll increase the timeouts of those test jobs; I'd prefer that we spend as long as we need on prepulling the test containers to prevent subsequent individual tests from timing out if their containers are not present and can't be pulled quickly enough.

TODO later:
  - Update the prepull list once again after https://github.com/kubernetes/kubernetes/pull/81226 is merged.
  - Move / remove prepull.yaml (Azure tests currently point at it).