### PR TITLE
Update prepulled containers again

### DIFF
--- a/gce/prepull-1.14.yaml
+++ b/gce/prepull-1.14.yaml
@@ -13,10 +13,20 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-      # To generate this list from the build-log.txt output of an e2e test
-      # result:
-      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
-      #   build-log.txt | sort | uniq
+      # To see containers that are known to be used in e2e tests, run this
+      # command against the build-log.txt output from a test run:
+      #   grep -v 'Node Info: &Node' build-log.txt \
+      #     | grep -ho -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #     | sort | uniq
+      # NOTE: this command captures only a subset of the test containers,
+      # unfortunately; not all test containers will have their names printed in
+      # the test output. Running the command against the output from multiple
+      # test runs is also recommended. Filtering out the 'Node Info' lines
+      # avoids capturing containers that are only found in the test log
+      # *because* we prepulled them. Overall this command may be useful for
+      # detecting newly-used test containers but there's not a great way to
+      # prune unused containers from this manifest right now.
+      #
       # DaemonSets do not support a RestartPolicy other than 'Always', so we
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
@@ -27,92 +37,56 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/curl:1803
-        name: curl2
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/java:openjdk-8-jre
-        name: java3
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/test-webserver:1.0
-        name: test-webserver4
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/cassandra:v13
-        name: cassandra5
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/dnsutils:1.1
-        name: dnsutils6
+        name: dnsutils-11
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/echoserver:2.2
-        name: echoserver7
+        name: echoserver-22
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/entrypoint-tester:1.0
-        name: entrypoint-tester8
+        name: entrypoint-tester-10
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/etcd:v3.3.10
-        name: etcd9
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:3.3.10
-        name: etcd10
+        name: etcd-v3310
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/fakegitserver:1.0
-        name: fakegitserver11
+        name: fakegitserver-10
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/gb-frontend:v6
-        name: gb-frontend12
+        name: gb-frontend-v6
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/gb-redisslave:v3
-        name: gb-redisslave13
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/hazelcast-kubernetes:3.8_1
-        name: hazelcast-kubernetes14
+        name: gb-redisslave-v3
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/hostexec:1.1
-        name: hostexec15
+        name: hostexec-11
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/iperf:1.0
-        name: iperf16
+        name: iperf-10
         resources:
           requests:
             cpu: 1m
@@ -195,14 +169,14 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/port-forward-tester:1.0
-        name: port-forward-tester30
+      - image: e2eteam/porter:1.0
+        name: porter31
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/porter:1.0
-        name: porter31
+      - image: e2eteam/port-forward-tester:1.0
+        name: port-forward-tester30
         resources:
           requests:
             cpu: 1m
@@ -213,26 +187,14 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/resource-consumer:1.4
-        name: resource-consumer33-1
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/resource-consumer:1.5
-        name: resource-consumer33-2
+        name: resource-consumer-15
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/resource-consumer-controller:1.0
         name: resource-consumer-controller34
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/rethinkdb:1.16.0_1
-        name: rethinkdb35
         resources:
           requests:
             cpu: 1m
@@ -249,8 +211,14 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/webhook:1.13v1
+      - image: e2eteam/webhook:1.14v1
         name: webhook38
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/test-webserver:1.0
+        name: test-webserver4
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-1.15.yaml
+++ b/gce/prepull-1.15.yaml
@@ -13,28 +13,26 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-      # To generate this list from the build-log.txt output of an e2e test
-      # result:
-      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
-      #   build-log.txt | sort | uniq
+      # To see containers that are known to be used in e2e tests, run this
+      # command against the build-log.txt output from a test run:
+      #   grep -v 'Node Info: &Node' build-log.txt \
+      #     | grep -ho -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #     | sort | uniq
+      # NOTE: this command captures only a subset of the test containers,
+      # unfortunately; not all test containers will have their names printed in
+      # the test output. Running the command against the output from multiple
+      # test runs is also recommended. Filtering out the 'Node Info' lines
+      # avoids capturing containers that are only found in the test log
+      # *because* we prepulled them. Overall this command may be useful for
+      # detecting newly-used test containers but there's not a great way to
+      # prune unused containers from this manifest right now.
+      #
       # DaemonSets do not support a RestartPolicy other than 'Always', so we
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
       containers:
       - image: e2eteam/busybox:1.29
         name: busybox1
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/cassandra:v13
-        name: cassandra5
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/curl:1803
-        name: curl2
         resources:
           requests:
             cpu: 1m
@@ -63,12 +61,6 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:v3.3.10
-        name: etcd10
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/fakegitserver:1.0
         name: fakegitserver11
         resources:
@@ -87,12 +79,6 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/hazelcast-kubernetes:3.8_1
-        name: hazelcast-kubernetes14
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/hostexec:1.1
         name: hostexec15
         resources:
@@ -101,12 +87,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/iperf:1.0
         name: iperf16
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/java:openjdk-8-jre
-        name: java-openjdk-8
         resources:
           requests:
             cpu: 1m
@@ -207,12 +187,6 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/resource-consumer:1.4
-        name: resource-consumer-14
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/resource-consumer:1.5
         name: resource-consumer-15
         resources:
@@ -227,6 +201,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/serve-hostname:1.1
         name: serve-hostname-11
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/webhook:1.15v1
+        name: webhook-115v1
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-1.16.yaml
+++ b/gce/prepull-1.16.yaml
@@ -13,10 +13,20 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-      # To generate this list from the build-log.txt output of an e2e test
-      # result:
-      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
-      #   build-log.txt | sort | uniq
+      # To see containers that are known to be used in e2e tests, run this
+      # command against the build-log.txt output from a test run:
+      #   grep -v 'Node Info: &Node' build-log.txt \
+      #     | grep -ho -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #     | sort | uniq
+      # NOTE: this command captures only a subset of the test containers,
+      # unfortunately; not all test containers will have their names printed in
+      # the test output. Running the command against the output from multiple
+      # test runs is also recommended. Filtering out the 'Node Info' lines
+      # avoids capturing containers that are only found in the test log
+      # *because* we prepulled them. Overall this command may be useful for
+      # detecting newly-used test containers but there's not a great way to
+      # prune unused containers from this manifest right now.
+      #
       # DaemonSets do not support a RestartPolicy other than 'Always', so we
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
@@ -33,18 +43,6 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/cassandra:v13
-        name: cassandra5
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/curl:1803
-        name: curl2
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/dnsutils:1.1
         name: dnsutils6
         resources:
@@ -57,26 +55,8 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/entrypoint-tester:1.0
-        name: entrypoint-tester8
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:3.3.10
-        name: etcd9
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:v3.3.10
-        name: etcd10
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/fakegitserver:1.0
-        name: fakegitserver11
+      - image: e2eteam/etcd:3.3.15
+        name: etcd-3315
         resources:
           requests:
             cpu: 1m
@@ -89,12 +69,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/gb-redisslave:v3
         name: gb-redisslave13
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/hazelcast-kubernetes:3.8_1
-        name: hazelcast-kubernetes14
         resources:
           requests:
             cpu: 1m
@@ -117,18 +91,6 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/iperf:1.0
-        name: iperf16
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/java:openjdk-8-jre
-        name: java-openjdk-8
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/jessie-dnsutils:1.0
         name: jessie-dnsutils17
         resources:
@@ -137,18 +99,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/kitten:1.0
         name: kitten18
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/liveness:1.1
-        name: liveness19
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/logs-generator:1.0
-        name: logs-generator-10
         resources:
           requests:
             cpu: 1m
@@ -179,6 +129,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/redis:5.0.5-alpine
         name: redis-505
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/sample-apiserver:1.10
+        name: sample-apiserver-110
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-1.17.yaml
+++ b/gce/prepull-1.17.yaml
@@ -13,14 +13,30 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-      # To generate this list from the build-log.txt output of an e2e test
-      # result:
-      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
-      #   build-log.txt | sort | uniq
+      # To see containers that are known to be used in e2e tests, run this
+      # command against the build-log.txt output from a test run:
+      #   grep -v 'Node Info: &Node' build-log.txt \
+      #     | grep -ho -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #     | sort | uniq
+      # NOTE: this command captures only a subset of the test containers,
+      # unfortunately; not all test containers will have their names printed in
+      # the test output. Running the command against the output from multiple
+      # test runs is also recommended. Filtering out the 'Node Info' lines
+      # avoids capturing containers that are only found in the test log
+      # *because* we prepulled them. Overall this command may be useful for
+      # detecting newly-used test containers but there's not a great way to
+      # prune unused containers from this manifest right now.
+      #
       # DaemonSets do not support a RestartPolicy other than 'Always', so we
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
       containers:
+      - image: e2eteam/agnhost:2.6
+        name: agnhost-26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/agnhost:2.8
         name: agnhost-28
         resources:
@@ -29,18 +45,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/busybox:1.29
         name: busybox1
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/cassandra:v13
-        name: cassandra5
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/curl:1803
-        name: curl2
         resources:
           requests:
             cpu: 1m
@@ -57,26 +61,8 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/entrypoint-tester:1.0
-        name: entrypoint-tester8
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:3.3.10
-        name: etcd9
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:v3.3.10
-        name: etcd10
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/fakegitserver:1.0
-        name: fakegitserver11
+      - image: e2eteam/etcd:3.4.3
+        name: etcd-343
         resources:
           requests:
             cpu: 1m
@@ -95,12 +81,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/httpd:2.4.39-alpine
         name: httpd-2439
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/java:openjdk-8-jre
-        name: java-openjdk-8
         resources:
           requests:
             cpu: 1m
@@ -137,6 +117,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/pause:3.1
         name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/sample-apiserver:1.10
+        name: sample-apiserver-110
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-1.18.yaml
+++ b/gce/prepull-1.18.yaml
@@ -13,14 +13,30 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-      # To generate this list from the build-log.txt output of an e2e test
-      # result:
-      #   grep -o -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
-      #   build-log.txt | sort | uniq
+      # To see containers that are known to be used in e2e tests, run this
+      # command against the build-log.txt output from a test run:
+      #   grep -v 'Node Info: &Node' build-log.txt \
+      #     | grep -ho -E 'e2eteam/([[:alnum:]_-]+):([[:alnum:]./_-]+)' \
+      #     | sort | uniq
+      # NOTE: this command captures only a subset of the test containers,
+      # unfortunately; not all test containers will have their names printed in
+      # the test output. Running the command against the output from multiple
+      # test runs is also recommended. Filtering out the 'Node Info' lines
+      # avoids capturing containers that are only found in the test log
+      # *because* we prepulled them. Overall this command may be useful for
+      # detecting newly-used test containers but there's not a great way to
+      # prune unused containers from this manifest right now.
+      #
       # DaemonSets do not support a RestartPolicy other than 'Always', so we
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
       containers:
+      - image: e2eteam/agnhost:2.6
+        name: agnhost-26
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/agnhost:2.8
         name: agnhost-28
         resources:
@@ -29,18 +45,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/busybox:1.29
         name: busybox1
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/cassandra:v13
-        name: cassandra5
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/curl:1803
-        name: curl2
         resources:
           requests:
             cpu: 1m
@@ -57,38 +61,20 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/entrypoint-tester:1.0
-        name: entrypoint-tester8
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:3.3.10
-        name: etcd9
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/etcd:3.4.3
         name: etcd-343
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/etcd:v3.3.10
-        name: etcd10
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/fakegitserver:1.0
-        name: fakegitserver11
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/gb-frontend:v6
         name: gb-frontend12
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: e2eteam/gb-redisslave:v3
+        name: gb-redisslave-v3
         resources:
           requests:
             cpu: 1m
@@ -101,12 +87,6 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/httpd:2.4.39-alpine
         name: httpd-2439
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/java:openjdk-8-jre
-        name: java-openjdk-8
         resources:
           requests:
             cpu: 1m


### PR DESCRIPTION
Removes some containers that are believed to be unused based on better test log filtering and comments on PR #126. Adds some containers that were detected by looking at multiple test logs.

Once https://github.com/kubernetes/kubernetes/pull/88022 gets merged it will let us see the list of containers present on the nodes at the end of the e2e test run, which I'll then compare against these manifests to detect if I've missed prepulling any containers. Unfortunately there's not an easy way to detect prepulled containers that need to be pruned.