### PR TITLE
Using nodeSelector & Tolerations to prepull test image

### DIFF
--- a/gce/load-test.sh
+++ b/gce/load-test.sh
@@ -7,22 +7,6 @@ set -o xtrace
 # When running in prow, the working directory is the root of the test-infra
 # repository.
 
-# Taint the Linux nodes to prevent the test workloads from landing on them.
-# TODO: remove this once the issue is resolved:
-# https://github.com/kubernetes/kubernetes/issues/69892
-LINUX_NODES=$(kubectl get nodes -l kubernetes.io/os=linux -o name)
-LINUX_NODE_COUNT=$(echo ${LINUX_NODES} | wc -w)
-for node in $LINUX_NODES; do
-  kubectl taint node $node node-under-test=false:NoSchedule
-done
-
-# Untaint the windows nodes to allow test workloads without tolerations to be
-# scheduled onto them.
-WINDOWS_NODES=$(kubectl get nodes -l kubernetes.io/os=windows -o name)
-for node in $WINDOWS_NODES; do
-  kubectl taint node $node node.kubernetes.io/os:NoSchedule-
-done
-
 # Pre-pull all the test images.
 SCRIPT_ROOT=$(cd `dirname $0` && pwd)
 kubectl create -f ${SCRIPT_ROOT}/loadtest-prepull.yaml

--- a/gce/loadtest-prepull.yaml
+++ b/gce/loadtest-prepull.yaml
@@ -15,5 +15,9 @@ spec:
         kubernetes.io/os: windows
       initContainers:
       containers:
-      - image: gcr.io/gke-release/pause-win:1.0.0
+      - image: gcr.io/gke-release/pause-win:1.1.0
         name: pause
+      tolerations:
+      - key: "node.kubernetes.io/os"
+        operator: "Exists"
+        effect: "NoSchedule"


### PR DESCRIPTION
Need to schedule prometheus server pods on linux nodes, so cannot taint linux node as before. Use nodeSelector & Tolerations to prepull test image on windows node.