### PR TITLE
Adds promoterE2eRegistry to image-repo-list

### DIFF
--- a/images/image-repo-list
+++ b/images/image-repo-list
@@ -1,5 +1,6 @@
 dockerLibraryRegistry: e2eteam
 e2eRegistry: e2eteam
+promoterE2eRegistry: e2eteam
 etcdRegistry: e2eteam
 gcRegistry: e2eteam
 hazelcastRegistry: e2eteam


### PR DESCRIPTION
We've recently enabled the Image Promoter to run over the k/k test images. It promotes the images into a different registry to the usual e2eRegistry, so a separate entry was needed.
This adds promoterE2eRegistry to the image-repo-list, which we now need.