### PR TITLE
Add two more people for aks-engine & Windows

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,5 +2,7 @@
 
 approvers:
   - adelina-t
+  - chewong
+  - marosset
   - michmike
   - PatrickLang


### PR DESCRIPTION
Mark and Ernest are also approvers on the SIG-Windows prow configs - https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/sig-windows/OWNERS

Those jobs reference the [job-templates](https://github.com/kubernetes-sigs/windows-testing/tree/master/job-templates) here, so they need access to update them too.