### PR TITLE
Use kubectl wait instead of sleeps in gce/run-e2e

### DIFF
--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -37,13 +37,13 @@ kubectl create -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a while for the test images to be pulled onto the nodes. In empirical
 # testing it could take up to 30 minutes to finish pulling all the test
 # containers on a node.
-sleep ${PREPULL_TIMEOUT:-30m}
+kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout ${PREPULL_TIMEOUT:-30m}
 # Check the status of the pods.
 kubectl get pods -o wide
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a few more minutes for the pod to be cleaned up.
-sleep 3m
+kubectl wait --for=delete pod -l prepull-test-images=e2e --timeout 3m
 
 # Download and set the list of test image repositories to use.
 curl \


### PR DESCRIPTION
This means we only wait as long as we need to, instead of always the maximum

/assign @pjh 