### PR TITLE
fix: explicitly set kubeconfig when using KUBECTL in CSE

### DIFF
--- a/extensions/gmsa-coredns/v1/update-coredns.sh
+++ b/extensions/gmsa-coredns/v1/update-coredns.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+
 # Get the IP of the DC as soon as it is available
 while [$DCIP = $null]
 do
-    DCIP=$(kubectl get node --selector="agentpool=windowsgmsa" -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}") > /dev/null 2>&1
+    DCIP=$(${KUBECTL} get node --selector="agentpool=windowsgmsa" -o jsonpath="{.items[*].status.addresses[?(@.type=='InternalIP')].address}") > /dev/null 2>&1
     sleep 5
 done
 
@@ -27,7 +30,7 @@ EOF
 sed "s/DCIP/${DCIP}/g" coredns-custom.sed > coredns-custom.yml
 
 # Apply the config file
-kubectl apply -f coredns-custom.yml
+${KUBECTL} apply -f coredns-custom.yml
 
 # Restart the CoreDNS pods to pick up the changes
-kubectl -n kube-system rollout restart deployment coredns
+${KUBECTL} -n kube-system rollout restart deployment coredns

--- a/extensions/master_extension/v1/win-e2e-master-extension.sh
+++ b/extensions/master_extension/v1/win-e2e-master-extension.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+KUBECONFIG="$(find /home/*/.kube/config)"
+KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+
 # Wait for coredns pod to be ready
 while true; do
-	COREDNS_READY=$(kubectl get pods -l k8s-app=kube-dns -n kube-system -o custom-columns=STATUS:status.containerStatuses[0].ready --no-headers)
+	COREDNS_READY=$(${KUBECTL} get pods -l k8s-app=kube-dns -n kube-system -o custom-columns=STATUS:status.containerStatuses[0].ready --no-headers)
 	if [ "${COREDNS_READY}" = "true" ]; then
 		echo "$(date -R) - coredns is ready" >> /tmp/master_extension.log
-		kubectl get pods --all-namespaces >> /tmp/master_extension.log
+		${KUBECTL} get pods --all-namespaces >> /tmp/master_extension.log
 		break
 	fi
 	sleep 2
@@ -13,27 +16,27 @@ done
 
 # Wait for all pods in kube-system namespace to be ready before applying taints
 while true; do
-	NOTREADY_PODS=$(kubectl get pods -n kube-system -o custom-columns=STATUS:status.containerStatuses[0].ready --no-headers | grep -v "true")
+	NOTREADY_PODS=$(${KUBECTL} get pods -n kube-system -o custom-columns=STATUS:status.containerStatuses[0].ready --no-headers | grep -v "true")
 	if [ -z "${NOTREADY_PODS}" ]; then
 		echo "$(date -R) - All kube-system pods are ready" >> /tmp/master_extension.log
-		kubectl get pods --all-namespaces >> /tmp/master_extension.log
+		${KUBECTL} get pods --all-namespaces >> /tmp/master_extension.log
 		break
 	fi
 	sleep 2
 done
 
-master_node=$(kubectl get nodes | grep master | awk '{print $1}')
+master_node=$(${KUBECTL} get nodes | grep master | awk '{print $1}')
 
-kubectl taint nodes "$master_node" node-role.kubernetes.io/master=:NoSchedule
-kubectl label nodes "$master_node" node-role.kubernetes.io/master=NoSchedule
+${KUBECTL} taint nodes "$master_node" node-role.kubernetes.io/master=:NoSchedule
+${KUBECTL} label nodes "$master_node" node-role.kubernetes.io/master=NoSchedule
 
 # Prepull images
-kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/gce/prepull.yaml
+${KUBECTL} create -f https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/gce/prepull.yaml
 # Wait 15 minutes for the test images to be pulled onto the nodes.
 sleep 15m
 # Check the status of the pods.
-kubectl get pods -o wide >> /tmp/master_extension.log
+${KUBECTL} get pods -o wide >> /tmp/master_extension.log
 # Delete the pods anyway since pre-pulling is best-effort
-kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/gce/prepull.yaml
+${KUBECTL} delete -f https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/gce/prepull.yaml
 # Wait a few more minutes for the pod to be cleaned up.
 sleep 3m


### PR DESCRIPTION
The latest kubectl built from k/k master branch causes kubectl commands to fail due to a new validation logic introduced in kubernetes/kubernetes@b19ad9e. 

```
error: Missing or incomplete configuration info.  Please point to an existing, complete config file:

  1. Via the command-line flag --kubeconfig
  2. Via the KUBECONFIG environment variable
  3. In your home directory as ~/.kube/config
```

This PR explicitly set kubeconfig when using kubectl to avoid this problem.

/hold
/assign @marosset 