### PR TITLE
Add an API model for in-tree storage e2e tests on Windows clusters

### DIFF
--- a/job-templates/kubernetes_storage.json
+++ b/job-templates/kubernetes_storage.json
@@ -1,0 +1,47 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "featureFlags": {
+            "enableTelemetry": true
+        },
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.18"
+        },
+        "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "",
+            "vmSize": "Standard_D2_v3"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "windowspool1",
+                "count": 2,
+                "vmSize": "Standard_D2s_v3",
+                "osDiskSizeGB": 128,
+                "availabilityProfile": "AvailabilitySet",
+                "osType": "Windows"
+            }
+        ],
+        "windowsProfile": {
+            "adminUsername": "azureuser",
+            "adminPassword": "replacepassword1234$",
+            "windowsDockerVersion": "19.03.5",
+            "sshEnabled": true
+        },
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": ""
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientID": "",
+            "secret": ""
+        }
+    }
+}


### PR DESCRIPTION
This API model will be used for in-tree storage e2e tests on Windows clusters.

/assign @marosset 