### PR TITLE
Add -T flag to scp

### DIFF
--- a/scripts/win-ci-logs-collector.sh
+++ b/scripts/win-ci-logs-collector.sh
@@ -111,7 +111,7 @@ function collect_windows_vm_logs {
 
     #Collecting provisioning logs
     for log_file in "${provisioning_logs[@]}"; do
-        scp ${SSH_OPTS} -o "ProxyJump ${USER}@${MASTER_IP}" ${USER}@${win_hostname}:"c:\\${log_file}" "${win_logs_location}/$(basename -- ${log_file})"
+        scp -T ${SSH_OPTS} -o "ProxyJump ${USER}@${MASTER_IP}" ${USER}@${win_hostname}:"c:\\${log_file}" "${win_logs_location}/$(basename -- ${log_file})"
         if [ ! $? -eq 0 ]
         then
             echo "Unable to collect log file ${log_file} from Windows Node ${win_hostname}. Skipping."
@@ -133,7 +133,7 @@ function collect_windows_vm_logs {
     $(ssh ${SSH_OPTS} -J ${USER}@${MASTER_IP} ${USER}@${win_hostname} "powershell.exe -c \"${win_logs_collector_script_path}\"")
     
     echo "Copying logs from Windows node ${win_hostname}"
-    scp ${SSH_OPTS} -o "ProxyJump ${USER}@${MASTER_IP}" ${USER}@${win_hostname}:"c:\\Users\\${USER}\\*.zip" "${win_logs_location}/debug.zip"
+    scp -T ${SSH_OPTS} -o "ProxyJump ${USER}@${MASTER_IP}" ${USER}@${win_hostname}:"c:\\Users\\${USER}\\*.zip" "${win_logs_location}/debug.zip"
     if [ ! $? -eq 0 ]
     then
         echo "Unable to collect log files from Windows Node ${win_hostname}. Skipping."


### PR DESCRIPTION
We see the following message when trying to scp some logs on Azure: `protocol error: filename does not match request`

We add -T flags to scp on Windows to fix this.

