### PR TITLE
Install csi-proxy for kubernetes_storage.json

### DIFF
--- a/job-templates/kubernetes_storage.json
+++ b/job-templates/kubernetes_storage.json
@@ -26,7 +26,8 @@
         "windowsProfile": {
             "adminUsername": "azureuser",
             "adminPassword": "replacepassword1234$",
-            "windowsDockerVersion": "19.03.5",
+            "csiProxyURL": "https://kubernetesartifacts.azureedge.net/csi-proxy/master/binaries/csi-proxy.tar.gz",
+            "enableCSIProxy": true,
             "sshEnabled": true
         },
         "linuxProfile": {


### PR DESCRIPTION
Updating cluster definition used for testing in-tree storage drivers to https://github.com/kubernetes-csi/csi-proxy on Windows nodes.