### PR TITLE
Update GCE files for switch to March node images

### DIFF
--- a/gce/load-test.sh
+++ b/gce/load-test.sh
@@ -10,13 +10,13 @@ set -o xtrace
 # Pre-pull all the test images.
 SCRIPT_ROOT=$(cd `dirname $0` && pwd)
 kubectl create -f ${SCRIPT_ROOT}/loadtest-prepull.yaml
-# Wait for the test images to be pulled onto the nodes.
-sleep ${PREPULL_TIMEOUT:-3m}
+# Wait a while for the test images to be pulled onto the nodes.
+kubectl wait --for=condition=ready pod -l prepull-test-images=loadtest --timeout ${PREPULL_TIMEOUT:-10m}
 # Check the status of the pods.
 kubectl get pods -o wide
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/loadtest-prepull.yaml
 # Wait a few more minutes for the pod to be cleaned up.
-sleep 1m
+kubectl wait --for=delete pod -l prepull-test-images=loadtest --timeout 3m
 
 $GOPATH/src/k8s.io/perf-tests/run-e2e.sh $@

--- a/gce/loadtest-prepull.yaml
+++ b/gce/loadtest-prepull.yaml
@@ -13,9 +13,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-      initContainers:
       containers:
-      - image: gcr.io/gke-release/pause-win:1.1.0
+      - image: gcr.io/gke-release/pause-win:1.2.0
         name: pause
       tolerations:
       - key: "node.kubernetes.io/os"

--- a/gce/prepull-1.18.yaml
+++ b/gce/prepull-1.18.yaml
@@ -27,18 +27,14 @@ spec:
       # detecting newly-used test containers but there's not a great way to
       # prune unused containers from this manifest right now.
       #
+      # Examining initImageConfigs() in https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go may also help, but many of the containers listed there are only used for Linux tests.
+      #
       # DaemonSets do not support a RestartPolicy other than 'Always', so we
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
       containers:
-      - image: e2eteam/agnhost:2.6
-        name: agnhost-26
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/agnhost:2.8
-        name: agnhost-28
+      - image: e2eteam/agnhost:2.12
+        name: agnhost-212
         resources:
           requests:
             cpu: 1m


### PR DESCRIPTION
Companion to https://github.com/kubernetes/kubernetes/pull/89601.

- Updates prepulled container manifest for e2e tests. I verified this works against both LTSC (2019) and SAC (1909) clusters with March node images using `kubectl create -f gce/prepull-1.18.yaml`.
- Updates loadtest's prepulled pause version from 1.1.0 to 1.2.0.
- Updates load-test.sh to look more like run-e2e.sh.

cc @adelina-t 