### PR TITLE
Describe pods after waiting for prepull

### DIFF
--- a/gce/hack-run-e2e.sh
+++ b/gce/hack-run-e2e.sh
@@ -40,6 +40,7 @@ kubectl create -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout ${PREPULL_TIMEOUT:-30m}
 # Check the status of the pods.
 kubectl get pods -o wide
+kubectl describe pods
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a few more minutes for the pod to be cleaned up.

--- a/gce/load-test.sh
+++ b/gce/load-test.sh
@@ -14,6 +14,7 @@ kubectl create -f ${SCRIPT_ROOT}/loadtest-prepull.yaml
 kubectl wait --for=condition=ready pod -l prepull-test-images=loadtest --timeout ${PREPULL_TIMEOUT:-10m}
 # Check the status of the pods.
 kubectl get pods -o wide
+kubectl describe pods
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/loadtest-prepull.yaml
 # Wait a few more minutes for the pod to be cleaned up.

--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -40,6 +40,7 @@ kubectl create -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout ${PREPULL_TIMEOUT:-30m}
 # Check the status of the pods.
 kubectl get pods -o wide
+kubectl describe pods
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a few more minutes for the pod to be cleaned up.


### PR DESCRIPTION
If prepulled containers fail to run, `describe pods` should show which containers are failing.

This will help current failures in our GCE Windows tests, where the test log only shows:

```
...
+ kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout 30m
timed out waiting for the condition on pods/prepull-test-containers-gxjhh
timed out waiting for the condition on pods/prepull-test-containers-mqf4j
timed out waiting for the condition on pods/prepull-test-containers-r96tp
+ kubectl get pods -o wide
NAME                            READY   STATUS             RESTARTS   AGE   IP          NODE                                           NOMINATED NODE   READINESS GATES
prepull-test-containers-gxjhh   14/17   CrashLoopBackOff   85         92m   10.64.2.3   e2e-726b009feb-d872a-windows-node-group-ltb5   <none>           <none>
prepull-test-containers-mqf4j   14/17   CrashLoopBackOff   84         92m   10.64.1.3   e2e-726b009feb-d872a-windows-node-group-0qdq   <none>           <none>
prepull-test-containers-r96tp   14/17   CrashLoopBackOff   82         92m   10.64.3.3   e2e-726b009feb-d872a-windows-node-group-lc19   <none>           <none>
+ kubectl delete -f /home/prow/go/src/k8s.io/windows-testing/gce/prepull-head.yaml
...
```