### PR TITLE
Remove httpd:2.4.38-alpine from prepull list

### DIFF
--- a/gce/prepull-1.18.yaml
+++ b/gce/prepull-1.18.yaml
@@ -75,12 +75,6 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: e2eteam/httpd:2.4.38-alpine
-        name: httpd-2438
-        resources:
-          requests:
-            cpu: 1m
-        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: e2eteam/httpd:2.4.39-alpine
         name: httpd-2439
         resources:


### PR DESCRIPTION
This is currently failing to prepull in our test jobs at head:

```
  httpd-2438:
    Container ID:  docker://                                                    6ae484f4093b6c8cba653c7a56f6b052616c6a5ca3de2e707a83199ca0976a01
    Image:         e2eteam/httpd:2.4.38-alpine
    Image ID:      docker-pullable://e2eteam/httpd@sha256:                      0cf7810e6cf7da9f0d0fe45ce05a24d15014da8668cfa70fb18b9e1f01604800
    Port:          <none>
    Host Port:     <none>
    Command:
      cmd.exe
      /c
      ping -n 1800 127.0.0.1 >NUL
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
```