### PR TITLE
Wrap kubectl wait with coreutils timeout

### DIFF
--- a/gce/hack-run-e2e.sh
+++ b/gce/hack-run-e2e.sh
@@ -37,14 +37,14 @@ kubectl create -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a while for the test images to be pulled onto the nodes. In empirical
 # testing it could take up to 30 minutes to finish pulling all the test
 # containers on a node.
-kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout ${PREPULL_TIMEOUT:-30m}
+timeout ${PREPULL_TIMEOUT:-30m} kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout -1s
 # Check the status of the pods.
 kubectl get pods -o wide
 kubectl describe pods
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a few more minutes for the pod to be cleaned up.
-kubectl wait --for=delete pod -l prepull-test-images=e2e --timeout 3m
+timeout 3m kubectl wait --for=delete pod -l prepull-test-images=e2e --timeout -1s
 
 # Download and set the list of test image repositories to use.
 curl \

--- a/gce/load-test.sh
+++ b/gce/load-test.sh
@@ -11,13 +11,13 @@ set -o xtrace
 SCRIPT_ROOT=$(cd `dirname $0` && pwd)
 kubectl create -f ${SCRIPT_ROOT}/loadtest-prepull.yaml
 # Wait a while for the test images to be pulled onto the nodes.
-kubectl wait --for=condition=ready pod -l prepull-test-images=loadtest --timeout ${PREPULL_TIMEOUT:-10m}
+timeout ${PREPULL_TIMEOUT:-10m} kubectl wait --for=condition=ready pod -l prepull-test-images=loadtest --timeout -1s
 # Check the status of the pods.
 kubectl get pods -o wide
 kubectl describe pods
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/loadtest-prepull.yaml
 # Wait a few more minutes for the pod to be cleaned up.
-kubectl wait --for=delete pod -l prepull-test-images=loadtest --timeout 3m
+timeout 3m kubectl wait --for=delete pod -l prepull-test-images=loadtest --timeout -1s
 
 $GOPATH/src/k8s.io/perf-tests/run-e2e.sh $@

--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -37,14 +37,14 @@ kubectl create -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a while for the test images to be pulled onto the nodes. In empirical
 # testing it could take up to 30 minutes to finish pulling all the test
 # containers on a node.
-kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout ${PREPULL_TIMEOUT:-30m}
+timeout ${PREPULL_TIMEOUT:-30m} kubectl wait --for=condition=ready pod -l prepull-test-images=e2e --timeout -1s
 # Check the status of the pods.
 kubectl get pods -o wide
 kubectl describe pods
 # Delete the pods anyway since pre-pulling is best-effort
 kubectl delete -f ${SCRIPT_ROOT}/${PREPULL_FILE}
 # Wait a few more minutes for the pod to be cleaned up.
-kubectl wait --for=delete pod -l prepull-test-images=e2e --timeout 3m
+timeout 3m kubectl wait --for=delete pod -l prepull-test-images=e2e --timeout -1s
 
 # Download and set the list of test image repositories to use.
 curl \


### PR DESCRIPTION
We discovered that kubectl wait will actually timeout only after timeout*number of objects being waited on. So if you wait on 3 pods specifying a timeout of 10m, it will actually wait 30m.

`kubectl sleep --timeout -1s` will wait a week, so plausibly "forever".

Fixes #158

kubernetes/kubectl#754

/assign @pjh

I checked and ensured that the kubekins image has `timeout` in it.