### PR TITLE
chore: set the count of master to 3 in windows cluster

### DIFF
--- a/job-templates/kubernetes_storage.json
+++ b/job-templates/kubernetes_storage.json
@@ -9,7 +9,7 @@
             "orchestratorRelease": "1.18"
         },
         "masterProfile": {
-            "count": 1,
+            "count": 3,
             "dnsPrefix": "",
             "vmSize": "Standard_D2_v3"
         },


### PR DESCRIPTION
The replicas of csi-azuredisk-controller and csi-azurefile-controller is 2. The controller can only run on Linux. So in the windows e2e tests, need two Linux machines at least. Otherwise, `helm install azuredisk-csi-driver` will fail.

For ask-engine, masters have count value of 1, 3, or 5 masters.

So here I set to 3.