### PR TITLE
chore: use csi-proxy v0.1.0

### DIFF
--- a/job-templates/kubernetes_storage.json
+++ b/job-templates/kubernetes_storage.json
@@ -26,7 +26,7 @@
         "windowsProfile": {
             "adminUsername": "azureuser",
             "adminPassword": "replacepassword1234$",
-            "csiProxyURL": "https://kubernetesartifacts.azureedge.net/csi-proxy/master/binaries/csi-proxy.tar.gz",
+            "csiProxyURL": "https://k8scsi.blob.core.windows.net/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
             "enableCSIProxy": true,
             "sshEnabled": true
         },


### PR DESCRIPTION
In order to enhance the robustness, use csi-proxy v0.1.0 instead of master version. 

/ping @andyzhangx @marosset @chewong 