### PR TITLE
Adding job template to test containerd with hyperv isolation enabled

### DIFF
--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -1,0 +1,87 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "featureFlags": {
+      "enableTelemetry": true
+    },
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.18",
+      "kubernetesConfig": {
+        "apiServerConfig": {
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "kubeletConfig": {
+          "--feature-gates": "KubeletPodResources=false"
+        },
+        "networkPlugin": "azure",
+        "containerRuntime": "containerd",
+        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd-0.0.87-public.zip",
+        "windowsSdnPluginURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cni-containerd-custom.zip"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "ubuntu",
+      "extensions": [
+        {
+          "name": "master_extension"
+        }
+      ]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 2,
+        "vmSize": "Standard_D2s_v3",
+        "osDiskSizeGB": 128,
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows",
+        "preProvisionExtension": {
+          "name": "agent_preprovision_extension",
+          "singleOrAll": "all"
+        }
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "sshEnabled": true,
+      "windowsPublisher": "microsoft-aks",
+      "windowsOffer": "aks-windows",
+      "windowsSku": "2019-datacenter-core-smalldisk-containerd-2005",
+      "imageVersion": "17763.1158.200501"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    },
+    "extensionProfiles": [
+      {
+        "name": "agent_preprovision_extension",
+        "version": "v1",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "node_setup.ps1"
+      },
+      {
+        "name": "master_extension",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "win-e2e-master-extension.sh"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds job-templates/kubernets_contaienrd_hyperv.json which configures containerd to configures the default pod sandbox to use hyperv isolation for WS2019 containers as the default.