### PR TITLE
ci: use nightly builds of containerd/hcsshim for Azure test passes

### DIFF
--- a/job-templates/kubernetes_containerd.json
+++ b/job-templates/kubernetes_containerd.json
@@ -16,7 +16,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cri-containerd-custom.zip",
+        "windowsContainerdURL": "https://github.com/marosset/windows-cri-containerd/releases/download/nightly/windows-cri-containerd.zip",
         "windowsSdnPluginURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cni-containerd-custom.zip"
       }
     },


### PR DESCRIPTION
Updating containerd test passses on Azure to use a .zip with containerd/depenancies built nightly from master branches.

Github actions template - https://github.com/marosset/windows-cri-containerd/blob/master/.github/workflows/windows-cri-containerd.yml