### PR TITLE
ci: Install csi-proxy for aks-engine containerd deployments

### DIFF
--- a/job-templates/kubernetes_containerd.json
+++ b/job-templates/kubernetes_containerd.json
@@ -48,6 +48,8 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
+      "csiProxyURL": "https://k8scsi.blob.core.windows.net/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
+      "enableCSIProxy": true,
       "sshEnabled": true
     },
     "linuxProfile": {


### PR DESCRIPTION
Named pipe mount support merged into containerd/cri which is required for CSI proxy to function.
