### PR TITLE
Add 2004 test config

### DIFF
--- a/job-templates/kubernetes_2004_master.json
+++ b/job-templates/kubernetes_2004_master.json
@@ -1,0 +1,81 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.18",
+      "kubernetesConfig": {
+        "kubeletConfig": {
+          "--feature-gates": "KubeletPodResources=false"
+        },
+        "apiServerConfig": {
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
+          "--feature-gates": "WindowsRunAsUserName=true"
+        }
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "ubuntu",
+      "extensions": [
+        {
+          "name": "master_extension"
+        }
+      ]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 2,
+        "vmSize": "Standard_D2s_v3",
+        "osDiskSizeGB": 128,
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows",
+        "preProvisionExtension": {
+          "name": "agent_preprovision_extension",
+          "singleOrAll": "all"
+        }
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "sshEnabled": true,
+      "windowsPublisher": "MicrosoftWindowsServer",
+      "windowsOffer": "WindowsServer",
+      "windowsSku": "datacenter-core-2004-with-containers-smalldisk",
+      "imageVersion": "19041.329.2006042019"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    },
+    "extensionProfiles": [
+      {
+        "name": "agent_preprovision_extension",
+        "version": "v1",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "node_setup.ps1"
+      },
+      {
+        "name": "master_extension",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "win-e2e-master-extension.sh"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds an aks-engine template for windows version 2004 config which will be used by the test job to be configured in https://github.com/kubernetes/test-infra to create test signal for Windows SAC version 2004.  sig-windows discussed added support for 2004 in last [sig-windows meeting](https://github.com/kubernetes/community/tree/master/sig-windows) on June 23 2020.