### PR TITLE
Fix for timeout spawning sub process and needs vars exported

### DIFF
--- a/extensions/master_extension/v1/win-e2e-master-extension.sh
+++ b/extensions/master_extension/v1/win-e2e-master-extension.sh
@@ -2,8 +2,8 @@
 
 echo "start master extension" >> /tmp/master_extension.log
 
-KUBECONFIG="$(find /home/*/.kube/config)"
-KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+export KUBECONFIG="$(find /home/*/.kube/config)"
+export KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
 
 wait_for_kube_system_pods() {
     while true; do

--- a/extensions/master_extension_prepull/v1/win-e2e-master-extension.sh
+++ b/extensions/master_extension_prepull/v1/win-e2e-master-extension.sh
@@ -2,8 +2,8 @@
 
 echo "start master extension" >> /tmp/master_extension.log
 
-KUBECONFIG="$(find /home/*/.kube/config)"
-KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
+export KUBECONFIG="$(find /home/*/.kube/config)"
+export KUBECTL="kubectl --kubeconfig=${KUBECONFIG}"
 
 wait_for_kube_system_pods() {
     while true; do


### PR DESCRIPTION
Fixes timeout on control nodes introduced with https://github.com/kubernetes-sigs/windows-testing/pull/178

`Timeout`  cmd spawns sub process and needs vars exported otherwise end up with error message during provisioning becuase `KUBECTL` varaible is missing

```
bash: line 1: get: command not found
bash: line 4: get: command not found
node/k8s-master-12396028-0 tainted
node/k8s-master-12396028-0 labeled
daemonset.apps/prepull created
daemonset.apps "prepull" deleted
```

which results in errors like:

```
 Jul  8 08:21:43.397: FAIL: Error waiting for all pods to be running and ready: 2 / 10 pods in namespace "kube-system" are NOT in RUNNING and READY state in 10m0s
```

```
Jul  8 00:34:49.082: INFO: >>> kubeConfig: /root/tmp013712723/kubeconfig/kubeconfig.eastus2.json
Jul  8 00:34:49.104: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
Jul  8 00:34:49.358: FAIL: Unexpected error:
    <*errors.errorString | 0xc002f2a7d0>: {
        s: "there are currently no ready, schedulable nodes in the cluster",
    }
    there are currently no ready, schedulable nodes in the cluster 
```