### PR TITLE
Update to new hyperv package and bump vm size

### DIFF
--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -16,7 +16,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.5.zip",
+        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.6.zip",
         "windowsSdnPluginURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cni-containerd-custom.zip"
       }
     },
@@ -35,7 +35,7 @@
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D2s_v3",
+        "vmSize": "Standard_D4s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",


### PR DESCRIPTION
This does two things:

- bumps containerd version for enabling emptry-dir
- make the vm size larger for hyperv.  Currently getting 10 pods onto a smaller sized vm is not feasible due to the nature of the hyperv containers using compute and memory to create the container "vm". 

The hyperv tests at were failing with the error and this version resolves the error.

```
Jul 22 23:14:01.571: FAIL: Unexpected error:
    <*errors.errorString | 0xc0030ac270>: {
        s: "expected pod \"var-expansion-e6bb6c54-358e-4918-9fdd-d20e81717ccf\" success: Gave up after waiting 5m0s for pod \"var-expansion-e6bb6c54-358e-4918-9fdd-d20e81717ccf\" to be \"Succeeded or Failed\"",
    }
    expected pod "var-expansion-e6bb6c54-358e-4918-9fdd-d20e81717ccf" success: Gave up after waiting 5m0s for pod "var-expansion-e6bb6c54-358e-4918-9fdd-d20e81717ccf" to be "Succeeded or Failed"
occurred
d20e81717ccf: {kubelet 4246k8s000} Failed: (combined from similar events): Error: failed to generate container "5304b5a2cc1e1ad369a339dc156f87deba256ab89b99c07afa08e001e515e2b2" spec: kubernetes.io~empty-dir mounts are only supported for LCOW%!(EXTRA string=c:\var\lib\kubelet\pods\3be8ad91-2ef8-4d97-ba5f-7e77ef87193b\volumes\kubernetes.io~empty-dir\workdir1\var-expansion-e6bb6c54-358e-4918-9fdd-d20e81717ccf)
```

/assign @chewong 

cc: @bingbing8