### PR TITLE
Adds gcAuthenticatedRegistry to image-repo-list

### DIFF
--- a/images/image-repo-list
+++ b/images/image-repo-list
@@ -1,6 +1,7 @@
 dockerLibraryRegistry: e2eteam
 e2eRegistry: e2eteam
 promoterE2eRegistry: e2eteam
+gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: e2eteam
 gcRegistry: e2eteam
 hazelcastRegistry: e2eteam


### PR DESCRIPTION
We've added the private image ``e2eprivate/windows-nanoserver:v1``. The image is a manifest list which contains images for 1809, 1903, 1909, 2004, and it will be used for the test ``[k8s.io] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]``.

Fixes Issue: https://github.com/kubernetes/kubernetes/issues/93048