### PR TITLE
Creates a separate image-repo-list file for 2004

### DIFF
--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -1,6 +1,7 @@
 dockerLibraryRegistry: e2eteam
 e2eRegistry: e2eteam
 promoterE2eRegistry: e2eteam
+gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: e2eteam
 gcRegistry: e2eteam
 hazelcastRegistry: e2eteam


### PR DESCRIPTION
We still need to keep the image-repo-list as is. The pull requests that can configure the tests to use a custom docker config.json file was merged in 1.19, so it wouldn't work for earlier releases.

Creates image-repo-list-2004 for 2004 jobs.