### PR TITLE
Update Hyperv package to 0.8

### DIFF
--- a/job-templates/kubernetes_2004_containerd.json
+++ b/job-templates/kubernetes_2004_containerd.json
@@ -47,7 +47,6 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
-      "enableCSIProxy": true,
       "sshEnabled": true,
       "windowsPublisher": "MicrosoftWindowsServer",
       "windowsOffer": "WindowsServer",

--- a/job-templates/kubernetes_2004_containerd_hyperv.json
+++ b/job-templates/kubernetes_2004_containerd_hyperv.json
@@ -35,7 +35,7 @@
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D2s_v3",
+        "vmSize": "Standard_D4s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",

--- a/job-templates/kubernetes_2004_containerd_hyperv.json
+++ b/job-templates/kubernetes_2004_containerd_hyperv.json
@@ -48,7 +48,6 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
-      "enableCSIProxy": true,
       "sshEnabled": true,
       "windowsPublisher": "MicrosoftWindowsServer",
       "windowsOffer": "WindowsServer",

--- a/job-templates/kubernetes_2004_containerd_hyperv.json
+++ b/job-templates/kubernetes_2004_containerd_hyperv.json
@@ -16,7 +16,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.6.zip",
+        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.8.zip",
         "windowsSdnPluginURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cni-containerd-custom.zip"
       }
     },

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -16,7 +16,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.6.zip",
+        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.8.zip",
         "windowsSdnPluginURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cni-containerd-custom.zip"
       }
     },


### PR DESCRIPTION
This pr updates:

- hyperv package to 0.8 - includes fix for the read only volume mount test
- gives 2004 hyperv vms larger size
- disables csi-proxy for 2004 tests since not being used