### PR TITLE
update to latest aks-windows image versions to fix failing jobs

### DIFF
--- a/job-templates/kubernetes_containerd.json
+++ b/job-templates/kubernetes_containerd.json
@@ -48,7 +48,11 @@
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
       "enableCSIProxy": true,
-      "sshEnabled": true
+      "sshEnabled": true,
+      "windowsPublisher": "microsoft-aks",
+      "windowsOffer": "aks-windows",
+      "windowsSku": "2019-datacenter-core-smalldisk-containerd-2005",
+      "imageVersion": "17763.1158.200502"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -52,7 +52,7 @@
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
       "windowsSku": "2019-datacenter-core-smalldisk-containerd-2005",
-      "imageVersion": "17763.1158.200501"
+      "imageVersion": "17763.1158.200502"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_csi_proxy.json
+++ b/job-templates/kubernetes_csi_proxy.json
@@ -28,7 +28,11 @@
             "adminPassword": "replacepassword1234$",
             "csiProxyURL": "https://k8scsi.blob.core.windows.net/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
             "enableCSIProxy": true,
-            "sshEnabled": true
+            "sshEnabled": true,
+            "windowsPublisher": "microsoft-aks",
+            "windowsOffer": "aks-windows",
+            "windowsSku": "2019-datacenter-core-smalldisk-2007",
+            "imageVersion": "17763.1339.200718"
         },
         "linuxProfile": {
             "adminUsername": "azureuser",

--- a/job-templates/kubernetes_in_tree_volume_plugins.json
+++ b/job-templates/kubernetes_in_tree_volume_plugins.json
@@ -26,7 +26,11 @@
         "windowsProfile": {
             "adminUsername": "azureuser",
             "adminPassword": "replacepassword1234$",
-            "sshEnabled": true
+            "sshEnabled": true,
+            "windowsPublisher": "microsoft-aks",
+            "windowsOffer": "aks-windows",
+            "windowsSku": "2019-datacenter-core-smalldisk-2007",
+            "imageVersion": "17763.1339.200718"
         },
         "linuxProfile": {
             "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -77,7 +77,7 @@
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
       "windowsSku": "2019-datacenter-core-smalldisk-2007",
-      "imageVersion": "17763.1282.200702"
+      "imageVersion": "17763.1339.200718"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
The tests using windows vhd's are failing due to old images not being available. 

can verify these images are available by running:

```
az vm image list --all --publisher microsoft-aks --offer aks-windows --output table
Offer        Publisher      Sku                                             Urn                                                                                         Version
-----------  -------------  ----------------------------------------------  ------------------------------------------------------------------------------------------  -----------------
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk                  microsoft-aks:aks-windows:2019-datacenter-core-smalldisk:17763.805.191025                   17763.805.191025
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-1912             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-1912:17763.864.191212              17763.864.191212
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2001             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2001:17763.973.200124              17763.973.200124
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2002             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2002:17763.1075.200228             17763.1075.200228
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2003             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2003:17763.1098.200327             17763.1098.200327
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2004             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2004:17763.1158.200422             17763.1158.200422
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2005             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2005:17763.1217.200514             17763.1217.200514
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2006             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2006:17763.1282.200626             17763.1282.200626
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2007             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2007:17763.1339.200718             17763.1339.200718
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2007             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2007:17763.1339.200719             17763.1339.200719
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-2008             microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-2008:17763.1397.200813             17763.1397.200813
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-aks-2007         microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-aks-2007:17763.1339.200718         17763.1339.200718
aks-windows  microsoft-aks  2019-datacenter-core-smalldisk-containerd-2005  microsoft-aks:aks-windows:2019-datacenter-core-smalldisk-containerd-2005:17763.1158.200502  17763.1158.200502
```