### PR TITLE
Updating aks-engine job templates for hyper-v isolated jobs

### DIFF
--- a/job-templates/kubernetes_2004_containerd_hyperv.json
+++ b/job-templates/kubernetes_2004_containerd_hyperv.json
@@ -54,7 +54,18 @@
       "windowsPublisher": "MicrosoftWindowsServer",
       "windowsOffer": "WindowsServer",
       "windowsSku": "Datacenter-Core-2004-with-Containers-smalldisk",
-      "imageVersion": "19041.329.2006042019"
+      "imageVersion": "19041.329.2006042019",
+      "windowsRuntimes": {
+        "default": "hyperv",
+        "hypervRuntimes": [
+          {
+            "buildNumber": "17763"
+          },
+          {
+            "buildNumber": "19041"
+          }
+        ]
+      }
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -16,8 +16,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.8.zip",
-        "windowsSdnPluginURL": "https://k8swin.blob.core.windows.net/k8s-windows/windows-cni-containerd-custom.zip"
+        "windowsContainerdURL": "https://k8swin.blob.core.windows.net/k8s-windows/containerd/containerplat-aks-test-0.0.8.zip"
       }
     },
     "masterProfile": {
@@ -52,7 +51,15 @@
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
       "windowsSku": "2019-datacenter-core-smalldisk-containerd-2005",
-      "imageVersion": "17763.1158.200502"
+      "imageVersion": "17763.1158.200502",
+      "windowsRuntimes": {
+        "default": "hyperv",
+        "hypervRuntimes": [
+          {
+            "buildNumber": "17763"
+          }
+        ]
+      }
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
Updating  aks-engine job templates for testing Hyper-V isolated containers.
Aks-engine v0.55.0 now has support for specifying what runtime classes should be configured on the node.
https://github.com/Azure/aks-engine/blob/master/docs/topics/features.md#hyper-v-support


This needs to merge After
- [x] https://github.com/kubernetes/test-infra/pull/19064
- [x] kubekins image is updated with above PR
- [x] https://github.com/kubernetes/test-infra/pull/19068