### PR TITLE
Adding aks-engine template for docker + GPU test jobs

### DIFF
--- a/job-templates/kubernetes_docker_gpu_master.json
+++ b/job-templates/kubernetes_docker_gpu_master.json
@@ -1,0 +1,72 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "featureFlags": {
+      "enableTelemetry": true
+    },
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "",
+      "kubernetesConfig": {
+        "apiServerConfig": {
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "kubeletConfig": {
+          "--feature-gates": "KubeletPodResources=false"
+        },
+        "networkPlugin": "azure",
+        "containerRuntime": "docker"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "aks-ubuntu-18.04",
+      "extensions": [
+        {
+          "name": "master_extension"
+        }
+      ]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 1,
+        "vmSize": "Standard_NC6",
+        "osDiskSizeGB": 128,
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "enableCSIProxy": true,
+      "sshEnabled": true
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    },
+    "extensionProfiles": [
+      {
+        "name": "master_extension",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "win-e2e-master-extension.sh"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I verified that the Azure subscription that aks-engine test passes run in can create NC6 VMs in **eastus** region.

I also verified I could start containers with GPD devices attached with
`docker run --isolation process --device class/5B45201D-F2F2-4F3B-85BB-30FF1F953599 mcr.microsoft.com/windows:1809`
https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/gpu-acceleration

This is needed to set up presubmit/periodic jobs for https://github.com/kubernetes/kubernetes/pull/93948