### PR TITLE
fix: set agent count to 2 for 1.17 API model

### DIFF
--- a/job-templates/kubernetes_release_1_17.json
+++ b/job-templates/kubernetes_release_1_17.json
@@ -32,7 +32,7 @@
     "agentPoolProfiles": [
       {
         "name": "windowspool1",
-        "count": 1,
+        "count": 2,
         "vmSize": "Standard_D2s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",


### PR DESCRIPTION
https://testgrid.k8s.io/provider-azure-windows#aks-engine-azure-1-17-windows was waiting for 2 agent nodes in the master extension script but the cluster only had 1 agent.

Signed-off-by: Ernest Wong <chuwon@microsoft.com>

