### PR TITLE
use lastest WS2019 image for kubernetes_release_staging job templates

### DIFF
--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -43,10 +43,10 @@
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
       "sshEnabled": true,
-      "windowsPublisher": "microsoft-aks",
-      "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2008",
-      "imageVersion": "17763.1397.200820"
+      "windowsPublisher": "MicrosoftWindowsServer",
+      "windowsOffer": "WindowsServer",
+      "windowsSku": "2019-Datacenter-Core-with-Containers-smalldisk",
+      "imageVersion": "latest"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -65,10 +65,10 @@
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
       "sshEnabled": true,
-      "windowsPublisher": "microsoft-aks",
-      "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2008",
-      "imageVersion": "17763.1397.200820"
+      "windowsPublisher": "MicrosoftWindowsServer",
+      "windowsOffer": "WindowsServer",
+      "windowsSku": "2019-Datacenter-Core-with-Containers-smalldisk",
+      "imageVersion": "latest"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
We're seeing reports of DNS issues with the Sept 2020 WS2019 patches so I want to see if this any repro in e2e tests.

