### PR TITLE
Set use managed explicitly

### DIFF
--- a/job-templates/kubernetes_1903_master.json
+++ b/job-templates/kubernetes_1903_master.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.25/azure-vnet-cni-linux-amd64-v1.0.25.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.25/azure-vnet-cni-windows-amd64-v1.0.25.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_1909_master.json
+++ b/job-templates/kubernetes_1909_master.json
@@ -5,6 +5,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_2004_containerd.json
+++ b/job-templates/kubernetes_2004_containerd.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_2004_master.json
+++ b/job-templates/kubernetes_2004_master.json
@@ -5,6 +5,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_1_19.json
+++ b/job-templates/kubernetes_containerd_1_19.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_1_19_serial.json
+++ b/job-templates/kubernetes_containerd_1_19_serial.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_csi_proxy.json
+++ b/job-templates/kubernetes_containerd_csi_proxy.json
@@ -8,6 +8,7 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "",
             "kubernetesConfig": {
+                "useManagedIdentity": false,
                 "containerRuntime": "containerd",
                 "windowsContainerdURL": "https://github.com/marosset/windows-cri-containerd/releases/download/nightly/windows-cri-containerd.zip"
             }

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_csi_proxy.json
+++ b/job-templates/kubernetes_csi_proxy.json
@@ -6,7 +6,10 @@
         },
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": ""
+            "orchestratorRelease": "",
+            "kubernetesConfig": {
+                "useManagedIdentity": false
+            }
         },
         "masterProfile": {
             "count": 1,

--- a/job-templates/kubernetes_docker_gpu_master.json
+++ b/job-templates/kubernetes_docker_gpu_master.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_in_tree_volume_plugins.json
+++ b/job-templates/kubernetes_in_tree_volume_plugins.json
@@ -6,7 +6,10 @@
         },
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": ""
+            "orchestratorRelease": "",
+            "kubernetesConfig": {
+                "useManagedIdentity": false
+            }
         },
         "masterProfile": {
             "count": 1,

--- a/job-templates/kubernetes_release_1_16.json
+++ b/job-templates/kubernetes_release_1_16.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.16",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.30/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.30/azure-vnet-cni-windows-amd64-v1.0.30.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_1_17.json
+++ b/job-templates/kubernetes_release_1_17.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.30/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.30/azure-vnet-cni-windows-amd64-v1.0.30.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_1_17_serial.json
+++ b/job-templates/kubernetes_release_1_17_serial.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.30/azure-vnet-cni-linux-amd64-v1.0.30.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.30/azure-vnet-cni-windows-amd64-v1.0.30.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_1_18.json
+++ b/job-templates/kubernetes_release_1_18.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.18",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_1_18_serial.json
+++ b/job-templates/kubernetes_release_1_18_serial.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.18",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_1_19.json
+++ b/job-templates/kubernetes_release_1_19.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_1_19_serial.json
+++ b/job-templates/kubernetes_release_1_19_serial.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -8,6 +8,7 @@
       "orchestratorType": "Kubernetes",
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
+        "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {


### PR DESCRIPTION
kube-apiserver is failing due to lack of --service-account-* so switched to use the aks-engine nightly was used which breaks the rest of the tests due to managed identity being used in aks-engine.

/assign @chewong @marosset 