### PR TITLE
fix: enable ExecProbeTimeout feature gate

### DIFF
--- a/job-templates/kubernetes_1903_master.json
+++ b/job-templates/kubernetes_1903_master.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.25/azure-vnet-cni-linux-amd64-v1.0.25.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.25/azure-vnet-cni-windows-amd64-v1.0.25.zip",
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",

--- a/job-templates/kubernetes_1909_master.json
+++ b/job-templates/kubernetes_1909_master.json
@@ -7,7 +7,7 @@
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",

--- a/job-templates/kubernetes_2004_containerd.json
+++ b/job-templates/kubernetes_2004_containerd.json
@@ -15,7 +15,7 @@
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_2004_master.json
+++ b/job-templates/kubernetes_2004_master.json
@@ -7,7 +7,7 @@
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -15,7 +15,7 @@
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -15,7 +15,7 @@
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-linux-amd64-v1.0.33.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.33/azure-vnet-cni-windows-amd64-v1.0.33.zip",
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Attempt to fix `Kubernetes e2e suite.[k8s.io] Probing container should be restarted with an exec liveness probe with timeout [NodeConformance]` by enabling ExecProbeTimeout feature gate, which is disabled by default by aks-engine.