### PR TITLE
fix: remove ExecProbeTimeout feature flag for 1903 API model

### DIFF
--- a/job-templates/kubernetes_1903_1_18.json
+++ b/job-templates/kubernetes_1903_1_18.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.25/azure-vnet-cni-linux-amd64-v1.0.25.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.0.25/azure-vnet-cni-windows-amd64-v1.0.25.zip",
         "kubeletConfig": {
-          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
+          "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

fixes https://testgrid.k8s.io/provider-azure-windows#aks-engine-azure-windows-1903-1-18 since ExecProbeTimeout is not available in 1.18.

/assign @jsturtevant 