### PR TITLE
Removing RunAsUserName feature gate from configs targeting master

### DIFF
--- a/job-templates/kubernetes_1909_master.json
+++ b/job-templates/kubernetes_1909_master.json
@@ -10,8 +10,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
-          "--feature-gates": "WindowsRunAsUserName=true"
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_2004_master.json
+++ b/job-templates/kubernetes_2004_master.json
@@ -10,8 +10,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
-          "--feature-gates": "WindowsRunAsUserName=true"
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },


### PR DESCRIPTION
The RunAsUserName feature gate has been GA since 1.18 and will be getting removing in v1.21 with https://github.com/kubernetes/kubernetes/pull/96531

Signed-off-by: Mark Rossetti <marosset@microsoft.com>