### PR TITLE
test images: create image-repo-list-master

### DIFF
--- a/images/image-repo-list-master
+++ b/images/image-repo-list-master
@@ -1,6 +1,5 @@
 dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

As we promoted more test images that are available for Windows nodes, I created `image-repo-list-master`, which uses the default `promoterE2eRegistry` in https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go#L78.

/assign @jsturtevant 
/cc @claudiubelu 
