### PR TITLE
Update prepull manifests for GCE Windows test jobs

### DIFF
--- a/gce/prepull-1.19.yaml
+++ b/gce/prepull-1.19.yaml
@@ -42,6 +42,12 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.20
+        name: agnhost-220
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/busybox:1.29
         name: busybox1
         resources:
@@ -74,6 +80,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/gb-redisslave:v3
         name: gb-redisslave-v3
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/httpd:2.4.38-alpine
+        name: httpd-2438
         resources:
           requests:
             cpu: 1m
@@ -116,6 +128,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/pause:3.1
         name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/pause:3.2
+        name: pause-32
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-1.20.yaml
+++ b/gce/prepull-1.20.yaml
@@ -42,6 +42,12 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.21
+        name: agnhost-221
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/busybox:1.29
         name: busybox1
         resources:
@@ -74,6 +80,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/gb-redisslave:v3
         name: gb-redisslave-v3
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/httpd:2.4.38-alpine
+        name: httpd-2438
         resources:
           requests:
             cpu: 1m
@@ -116,6 +128,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/pause:3.1
         name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/pause:3.2
+        name: pause-32
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-1.21.yaml
+++ b/gce/prepull-1.21.yaml
@@ -42,6 +42,12 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.26
+        name: agnhost-226
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/busybox:1.29
         name: busybox1
         resources:
@@ -78,6 +84,12 @@ spec:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/httpd:2.4.38-alpine
+        name: httpd-2438
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/httpd:2.4.39-alpine
         name: httpd-2439
         resources:
@@ -103,7 +115,13 @@ spec:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/nautilus:1.0
-        name: nautilus22
+        name: nautilus10
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/nautilus:1.4
+        name: nautilus14
         resources:
           requests:
             cpu: 1m
@@ -116,6 +134,12 @@ spec:
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
       - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/pause:3.1
         name: pause-31
+        resources:
+          requests:
+            cpu: 1m
+        command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
+      - image: k8sprow.azurecr.io/kubernetes-e2e-test-images/pause:3.2
+        name: pause-32
         resources:
           requests:
             cpu: 1m

--- a/gce/prepull-head.yaml
+++ b/gce/prepull-head.yaml
@@ -1,1 +1,1 @@
-prepull-1.18.yaml
+prepull-1.21.yaml


### PR DESCRIPTION
It's been a while since we updated the manifests for the test containers that should be [prepulled](https://github.com/kubernetes-sigs/windows-testing/pulls?q=is%3Apr+pjh+prepull) onto GCE Windows K8s nodes before e2e test jobs start. This PR adds prepull manifests for the versions currently tested on the [google-windows](https://testgrid.k8s.io/google-windows#gce-windows-2019-master&width=20) testgrid.

The comments in the prepull files include a `grep` command to run against `build-log.txt` from an e2e test run in order to generate a complete-ish list of the test containers used. I ran this for test output for 1.19, 1.20 and 1.21 to create this change.

At worst this change should have no effect on our test jobs; at best it may reduce some flakiness due to timeouts when pulling test containers.