### PR TITLE
Fix images/image-repo-list-2004

### DIFF
--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -1,5 +1,6 @@
 dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+promoterE2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images


### PR DESCRIPTION
This line was deleted as part of the PR https://github.com/kubernetes-sigs/windows-testing/pull/233.

It caused multiple failures to the `containerd-windows-sac2004-sdnbridge`
and `containerd-windows-sac2004-sdnoverlay` testing prow jobs from:
https://testgrid.k8s.io/sig-windows-networking

Both SAC 2004 prow jobs were using this `images-repo-list-2004`, and
they started failing due to being unable to pull the images from the default
registry.