### PR TITLE
Changes gcRegistry to gcEtcdRegistry

### DIFF
--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -2,7 +2,7 @@ dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 PrivateRegistry: e2eteam
 sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images

--- a/images/image-repo-list-master
+++ b/images/image-repo-list-master
@@ -1,7 +1,7 @@
 dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 PrivateRegistry: e2eteam
 sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images


### PR DESCRIPTION
The gcRegistry contains both the pause and etcd images. We should use the official pause image in testing, but the etcd image does not contain Windows support yet.

Related: https://github.com/kubernetes/kubernetes/pull/98926