### PR TITLE
chore: remove dockerLibraryRegistry from image-repo-list

### DIFF
--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -1,4 +1,3 @@
-dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images

--- a/images/image-repo-list-master
+++ b/images/image-repo-list-master
@@ -1,4 +1,3 @@
-dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Removed `dockerLibraryRegistry ` since it's removed in https://github.com/kubernetes/kubernetes/pull/98964, and all the dockerhub images have been migrated to `k8s.gcr.io/e2e-test-images`.

/hold
/assign @marosset 
/cc @claudiubelu 