### PR TITLE
Support configurable image-repo-list sources in GCE Windows tests.

### DIFF
--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -48,7 +48,7 @@ timeout 3m kubectl wait --for=delete pod -l prepull-test-images=e2e --timeout -1
 
 # Download and set the list of test image repositories to use.
 curl \
-  https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list \
+  ${KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION:-https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list} \
   -o ${WORKSPACE}/repo-list.yaml
 export KUBE_TEST_REPO_LIST=${WORKSPACE}/repo-list.yaml
 


### PR DESCRIPTION
This mimics the aksengine.go logic for downloading image-repo-list from a different location based on KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION. This will fix a bunch of test failures in the GCE Windows dashboards because of the missing jessie-dnsutils:1.4 image.

/sig windows
/priority important-soon

This change is a build on https://github.com/kubernetes-sigs/windows-testing/pull/244 which only modified the hack file.