### PR TITLE
test: update pause-win image to the new one k8s.gcr.io/pause:3.4.1

### DIFF
--- a/gce/loadtest-prepull.yaml
+++ b/gce/loadtest-prepull.yaml
@@ -14,7 +14,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: windows
       containers:
-      - image: gcr.io/gke-release/pause-win:1.2.1
+      - image: k8s.gcr.io/pause:3.4.1
         name: pause
       - image: mcr.microsoft.com/windows/servercore/iis
         name: iis


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As part of the efforts described in this Issue: https://github.com/kubernetes/k8s.io/issues/1525 we are trying to move away from `gcp project gke-release`

Also the pause image was release with windows support as we can see in the merged or in k/k https://github.com/kubernetes/kubernetes/pull/98205

/assign @spiffxp @jayunit100
