### PR TITLE
fix: overwrite --service-account-issuer

### DIFF
--- a/job-templates/kubernetes_1909_master.json
+++ b/job-templates/kubernetes_1909_master.json
@@ -10,6 +10,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
+          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -12,6 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-linux-amd64-v1.2.2.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-windows-amd64-v1.2.2.zip",
         "apiServerConfig": {
+          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -12,6 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-linux-amd64-v1.2.2.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-windows-amd64-v1.2.2.zip",
         "apiServerConfig": {
+          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -15,6 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
+          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Attempts to fix the following test case
```
Kubernetes e2e suite.[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer [Conformance]
```
in https://testgrid.k8s.io/sig-release-master-informing#aks-engine-azure-windows-master-containerd. 

Looks like we need to prepend `https://` for `--service-account-issuer` but aks-engine doesn't do that currently (https://github.com/Azure/aks-engine/blob/master/pkg/api/defaults-apiserver.go#L104). If this fixes the test failure, I will open a PR against aks-engine.