### PR TITLE
chore: add gcHttpdRegistry in image-repo-list

### DIFF
--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -2,6 +2,7 @@ e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcAuthenticatedRegistry: e2eprivate
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+gcHttpdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 PrivateRegistry: e2eteam
 sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images

--- a/images/image-repo-list-master
+++ b/images/image-repo-list-master
@@ -1,6 +1,7 @@
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+gcHttpdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 PrivateRegistry: e2eteam
 sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Temporarily pointing httpd registry to ACR to mitigate https://github.com/kubernetes/kubernetes/issues/99047.