### PR TITLE
fix: add image-repo-list-pr and add promoterE2eRegistry to image-repo-list-master

### DIFF
--- a/images/image-repo-list-pr
+++ b/images/image-repo-list-pr
@@ -1,5 +1,4 @@
 e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-promoterE2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcHttpdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

This points `promoterE2eRegistry` back to `k8sprow.azurecr.io/kubernetes-e2e-test-images` for now to mitigate https://github.com/kubernetes/kubernetes/issues/99325 and potential test image issues until they are stable. Copied the following test images from k8s.gcr.io in preparation for this PR.

Image | Version
-- | --
Agnhost | 2.28
Sample-apiserver | 1.17.4
Etcd | 3.4.13-0
Jessie-dnsutils | 1.4
Kitten | 1.4
Nautilus | 1.4
Nonroot | 1.1
Resource-consumer | 1.9



This PR also adds `image-repo-list-pr`, which uses the default `promoterE2eRegistry` so we can test changes introduced to test images by PRs in k/k.

/assign @jsturtevant 
/cc @claudiubelu 