### PR TITLE
fix: remove service-account-issuer apiserver flag

### DIFF
--- a/job-templates/kubernetes_1909_master.json
+++ b/job-templates/kubernetes_1909_master.json
@@ -10,7 +10,6 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -12,7 +12,6 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-linux-amd64-v1.2.2.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-windows-amd64-v1.2.2.zip",
         "apiServerConfig": {
-          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -12,7 +12,6 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-linux-amd64-v1.2.2.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.2/azure-vnet-cni-windows-amd64-v1.2.2.zip",
         "apiServerConfig": {
-          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -15,7 +15,6 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--service-account-issuer": "https://kubernetes.default.svc.cluster.local",
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         }
       }


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

- removed `--service-account-issuer` flag from apiserver config since it's now the default for aks-engine.
- ~set `runUnattendedUpgradesOnBootstrap` to false so master nodes won't reboot during the test pass while using nightly aks-engine build (we are using aks-engine v0.60.0 to avoid this problem)~ (addressed by https://github.com/kubernetes/test-infra/pull/21320)

/assign @jsturtevant @marosset 
/hold

