### PR TITLE
Cleans up image repo lists

### DIFF
--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -1,10 +1,3 @@
-e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcAuthenticatedRegistry: e2eprivate
-etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcHttpdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-PrivateRegistry: e2eteam
-sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-stormRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-zookeeperRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+privateRegistry: e2eteam

--- a/images/image-repo-list-master
+++ b/images/image-repo-list-master
@@ -1,9 +1,2 @@
-e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcHttpdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-PrivateRegistry: e2eteam
-sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-stormRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-zookeeperRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+privateRegistry: e2eteam

--- a/images/image-repo-list-pr
+++ b/images/image-repo-list-pr
@@ -1,9 +1,2 @@
-e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcHttpdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-hazelcastRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-PrivateRegistry: e2eteam
-sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-stormRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-zookeeperRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+privateRegistry: e2eteam


### PR DESCRIPTION
Removed unused entries from image_repo_list files:

- ``e2eRegistry``: The only image left in that registry is ``cuda-vector-add:1.0``, which is not Windows-specific.
- ``etcdRegistry``: Doesn't exist in ``kubernetes/utils/image/manifest.go``, there's only ``GcEtcdRegistry``.
- ``gcHttpdRegistry``: No longer needed, we've fixed the ``httpd`` image for Windows.
- ``hazelcastRegistry``: The test in which it was used  was removed in Kubernetes v1.13.
- ``sampleRegistry``: No images left in that registry.
- ``stormRegistry``: refers to the registry used for the storm-nimbus image. The test in which it was used  was removed in Kubernetes v1.13
- ``zookeeperRegistry``: same as ``stormRegistry``. There is a ``zookeeper-installer`` image that is currently in   the ``k8s.gcr.io/e2e-test-images`` registry, which doesn't have Windows support.

Changed ``PrivateRegistry`` to ``privateRegistry``, since that was a typo, ``kubernetes/utils/image/manifest.go`` expects it to be the latter [1].

[1]  https://github.com/kubernetes/kubernetes/blob/1a983bb958ba663e5d86983c55a187fb8c429c51/test/utils/image/manifest.go#L42