### PR TITLE
Don't rely on the extracted files being on disk

### DIFF
--- a/scripts/win-ci-logs-collector.sh
+++ b/scripts/win-ci-logs-collector.sh
@@ -124,7 +124,7 @@ function collect_windows_vm_logs {
     if $(ssh ${SSH_OPTS} -J ${USER}@${MASTER_IP} ${USER}@${win_hostname} "powershell.exe -c Test-Path ${win_logs_collector_script_path}" | grep -q "False")
     then
         echo "Downloading log collector script to Windows machine ${win_hostname}."
-        if $(ssh ${SSH_OPTS} -J ${USER}@${MASTER_IP} ${USER}@${win_hostname} "powershell.exe -c \". C:\\AzureData\\k8s\\kuberneteswindowsfunctions.ps1 ; DownloadFileOverHttp -Url ${win_logs_collector_script_url} -DestinationPath ${win_logs_collector_script_path} \""); then
+        if $(ssh ${SSH_OPTS} -J ${USER}@${MASTER_IP} ${USER}@${win_hostname} "powershell.exe -c \"curl.exe --retry 5 --retry-delay 0 -L ${win_logs_collector_script_url} -o ${win_logs_collector_script_path} \""); then
             echo "Unable to download logs_collector_script to machine ${win_hostname}"
             return 1
         fi


### PR DESCRIPTION
In a recent run a node didn't come online. The [log collection](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd/1374061007583842304) failed with:

```
Downloading log collector script to Windows machine 3474k8s001.
Warning: Permanently added 'kubetest-0nddyzc3.southcentralus.cloudapp.azure.com,20.188.89.181' (ECDSA) to the list of known hosts.

Authorized uses only. All activity may be monitored and reported.
Warning: Permanently added '3474k8s001' (ECDSA) to the list of known hosts.
Test-Path : Cannot bind argument to parameter 'Path' because it is null.
At C:\AzureData\k8s\kuberneteswindowsfunctions.ps1:23 char:19
+     if (Test-Path $global:CacheDir) {
+                   ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.TestPathCom 
   mand 
```

This removes the dependency on the those files which might not be present so we can still collect files for investigation.

/cc @chewong @marosset 