### PR TITLE
fix: bump kube-addon-manager to v9.1.5

### DIFF
--- a/job-templates/kubernetes_2004_containerd.json
+++ b/job-templates/kubernetes_2004_containerd.json
@@ -19,7 +19,19 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz",
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_2004_master.json
+++ b/job-templates/kubernetes_2004_master.json
@@ -11,7 +11,19 @@
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
-        }
+        },
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_20h2_master.json
+++ b/job-templates/kubernetes_20h2_master.json
@@ -13,7 +13,19 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz",
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_containerd_csi_proxy.json
+++ b/job-templates/kubernetes_containerd_csi_proxy.json
@@ -10,7 +10,19 @@
             "kubernetesConfig": {
                 "useManagedIdentity": false,
                 "containerRuntime": "containerd",
-                "windowsContainerdURL": "https://acs-mirror.azureedge.net/containerd/windows/v0.0.41/binaries/containerd-v0.0.41-windows-amd64.tar.gz"
+                "windowsContainerdURL": "https://acs-mirror.azureedge.net/containerd/windows/v0.0.41/binaries/containerd-v0.0.41-windows-amd64.tar.gz",
+                "components": [
+                    {
+                        "name": "kube-addon-manager",
+                        "enabled": true,
+                        "containers": [
+                            {
+                                "name": "kube-addon-manager",
+                                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+                            }
+                        ]
+                    }
+                ]
             }
         },
         "masterProfile": {

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -19,7 +19,19 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://kubernetesartifacts.azureedge.net/containerd/ms/0.0.14/binaries/containerd-windows-0.0.14.zip"
+        "windowsContainerdURL": "https://kubernetesartifacts.azureedge.net/containerd/ms/0.0.14/binaries/containerd-windows-0.0.14.zip",
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -19,7 +19,19 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz",
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -19,7 +19,19 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-windows-amd64.tar.gz",
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_csi_proxy.json
+++ b/job-templates/kubernetes_csi_proxy.json
@@ -8,7 +8,19 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "",
             "kubernetesConfig": {
-                "useManagedIdentity": false
+                "useManagedIdentity": false,
+                "components": [
+                    {
+                        "name": "kube-addon-manager",
+                        "enabled": true,
+                        "containers": [
+                            {
+                                "name": "kube-addon-manager",
+                                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+                            }
+                        ]
+                    }
+                ]
             }
         },
         "masterProfile": {

--- a/job-templates/kubernetes_docker_gpu_master.json
+++ b/job-templates/kubernetes_docker_gpu_master.json
@@ -16,7 +16,19 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "networkPlugin": "azure",
-        "containerRuntime": "docker"
+        "containerRuntime": "docker",
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -16,7 +16,19 @@
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
-        }
+        },
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -16,7 +16,19 @@
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
-        }
+        },
+        "components": [
+          {
+            "name": "kube-addon-manager",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "kube-addon-manager",
+                "image": "mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5"
+              }
+            ]
+          }
+        ]
       }
     },
     "masterProfile": {


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

/hold
until mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v9.1.5 is available.

/assign @jsturtevant 
