### PR TITLE
Add --disable-log-dump flag to disable k/k log dump path

### DIFF
--- a/gce/hack-run-e2e.sh
+++ b/gce/hack-run-e2e.sh
@@ -57,6 +57,4 @@ export KUBE_TEST_REPO_LIST=${WORKSPACE}/repo-list.yaml
 # The test framework will not proceed to run tests unless all nodes are ready
 # AND schedulable. Allow not-ready nodes since we make Linux nodes
 # unschedulable.
-# Do not set --disable-log-dump because upstream cannot handle dumping logs
-# from windows nodes yet.
-./hack/ginkgo-e2e.sh "$@" --report-dir=${ARTIFACTS} --allowed-not-ready-nodes=${LINUX_NODE_COUNT}
+./hack/ginkgo-e2e.sh "$@" --report-dir=${ARTIFACTS} --allowed-not-ready-nodes=${LINUX_NODE_COUNT} --disable-log-dump

--- a/gce/run-e2e.sh
+++ b/gce/run-e2e.sh
@@ -57,6 +57,4 @@ export KUBE_TEST_REPO_LIST=${WORKSPACE}/repo-list.yaml
 # The test framework will not proceed to run tests unless all nodes are ready
 # AND schedulable. Allow not-ready nodes since we make Linux nodes
 # unschedulable.
-# Do not set --disable-log-dump because upstream cannot handle dumping logs
-# from windows nodes yet.
-./hack/ginkgo-e2e.sh $@ --report-dir=${ARTIFACTS} --allowed-not-ready-nodes=${LINUX_NODE_COUNT}
+./hack/ginkgo-e2e.sh $@ --report-dir=${ARTIFACTS} --allowed-not-ready-nodes=${LINUX_NODE_COUNT} --disable-log-dump


### PR DESCRIPTION
According to https://github.com/kubernetes/kubernetes/pull/102337, need to add `--disable-log-dump` to trigger log dump from test-infra instead of k/k. 
Relevant Slack discussion: https://kubernetes.slack.com/archives/C09QZTRH7/p1621986566037600.