### PR TITLE
Add model for hostprocess tests and containerd 1.5

### DIFF
--- a/job-templates/kubernetes_containerd_1_5.json
+++ b/job-templates/kubernetes_containerd_1_5.json
@@ -1,0 +1,80 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "featureFlags": {
+      "enableTelemetry": true
+    },
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "",
+      "kubernetesConfig": {
+        "useManagedIdentity": false,
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.8/azure-vnet-cni-linux-amd64-v1.2.8.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.8/azure-vnet-cni-windows-amd64-v1.2.8.zip",
+        "apiServerConfig": {
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "kubeletConfig": {
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
+        },
+        "networkPlugin": "azure",
+        "containerRuntime": "containerd",
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.5.2/containerd-1.5.2-windows-amd64.tar.gz"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "aks-ubuntu-18.04",
+      "extensions": [
+        {
+          "name": "master_extension"
+        }
+      ]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 2,
+        "vmSize": "Standard_D2s_v3",
+        "osDiskSizeGB": 128,
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "enableCSIProxy": true,
+      "sshEnabled": true,
+      "windowsPublisher": "microsoft-aks",
+      "windowsOffer": "aks-windows",
+      "windowsSku": "2019-datacenter-core-ctrd-2104",
+      "imageVersion": "17763.1879.210414"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    },
+    "extensionProfiles": [
+      {
+        "name": "master_extension",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "win-e2e-master-extension.sh"
+      }
+    ]
+  }
+}

--- a/job-templates/kubernetes_containerd_master-hostprocess.json
+++ b/job-templates/kubernetes_containerd_master-hostprocess.json
@@ -1,0 +1,81 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "featureFlags": {
+      "enableTelemetry": true
+    },
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "",
+      "kubernetesConfig": {
+        "useManagedIdentity": false,
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.8/azure-vnet-cni-linux-amd64-v1.2.8.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.8/azure-vnet-cni-windows-amd64-v1.2.8.zip",
+        "apiServerConfig": {
+          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
+          "--feature-gates": "WindowsHostProcessContainers=true"
+        },
+        "kubeletConfig": {
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false,WindowsHostProcessContainers=true"
+        },
+        "networkPlugin": "azure",
+        "containerRuntime": "containerd",
+        "windowsContainerdURL": "https://testgridjs.blob.core.windows.net/containerd/containerd-1.5.2-windows-hostprocess-amd64.tar.gz"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v3",
+      "distro": "aks-ubuntu-18.04",
+      "extensions": [
+        {
+          "name": "master_extension"
+        }
+      ]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "count": 2,
+        "vmSize": "Standard_D2s_v3",
+        "osDiskSizeGB": 128,
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "enableCSIProxy": true,
+      "sshEnabled": true,
+      "windowsPublisher": "microsoft-aks",
+      "windowsOffer": "aks-windows",
+      "windowsSku": "2019-datacenter-core-ctrd-2104",
+      "imageVersion": "17763.1879.210414"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    },
+    "extensionProfiles": [
+      {
+        "name": "master_extension",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/",
+        "script": "win-e2e-master-extension.sh"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds a model with appropriate alpha settings for Hostprocess.

It also has a containerd 1.5.2 build with a containerd-shim built from https://github.com/microsoft/hcsshim/pull/962

/sig windows 
/assign @chewong 