### PR TITLE
Job dep updates

### DIFF
--- a/job-templates/kubernetes_2004_containerd.json
+++ b/job-templates/kubernetes_2004_containerd.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_1_19.json
+++ b/job-templates/kubernetes_containerd_1_19.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_1_19.json
+++ b/job-templates/kubernetes_containerd_1_19.json
@@ -50,8 +50,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_19_serial.json
+++ b/job-templates/kubernetes_containerd_1_19_serial.json
@@ -72,8 +72,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_19_serial.json
+++ b/job-templates/kubernetes_containerd_1_19_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_1_20.json
+++ b/job-templates/kubernetes_containerd_1_20.json
@@ -49,8 +49,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2101",
-      "imageVersion": "17763.1637.210111"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_20.json
+++ b/job-templates/kubernetes_containerd_1_20.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.20",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_1_20_serial.json
+++ b/job-templates/kubernetes_containerd_1_20_serial.json
@@ -71,8 +71,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2101",
-      "imageVersion": "17763.1637.210111"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_20_serial.json
+++ b/job-templates/kubernetes_containerd_1_20_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.20",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_1_21.json
+++ b/job-templates/kubernetes_containerd_1_21.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.21",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_1_21.json
+++ b/job-templates/kubernetes_containerd_1_21.json
@@ -49,8 +49,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2101",
-      "imageVersion": "17763.1637.210111"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_21_serial.json
+++ b/job-templates/kubernetes_containerd_1_21_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.21",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_1_21_serial.json
+++ b/job-templates/kubernetes_containerd_1_21_serial.json
@@ -71,8 +71,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2101",
-      "imageVersion": "17763.1637.210111"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_22.json
+++ b/job-templates/kubernetes_containerd_1_22.json
@@ -6,17 +6,20 @@
     },
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.18",
+      "orchestratorRelease": "1.22",
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
-        }
+        },
+        "networkPlugin": "azure",
+        "containerRuntime": "containerd",
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.5.4/containerd-1.5.4-windows-amd64.tar.gz"
       }
     },
     "masterProfile": {
@@ -46,8 +49,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2101",
+      "imageVersion": "17763.1637.210111"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_22.json
+++ b/job-templates/kubernetes_containerd_1_22.json
@@ -49,8 +49,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2101",
-      "imageVersion": "17763.1637.210111"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_22.json
+++ b/job-templates/kubernetes_containerd_1_22.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.22",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_1_22_serial.json
+++ b/job-templates/kubernetes_containerd_1_22_serial.json
@@ -71,8 +71,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2101",
-      "imageVersion": "17763.1637.210111"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_22_serial.json
+++ b/job-templates/kubernetes_containerd_1_22_serial.json
@@ -6,17 +6,20 @@
     },
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.18",
+      "orchestratorRelease": "1.22",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.8/azure-vnet-cni-linux-amd64-v1.2.8.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.2.8/azure-vnet-cni-windows-amd64-v1.2.8.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
         "kubeletConfig": {
-          "--feature-gates": "KubeletPodResources=false"
+          "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
-        }
+        },
+        "networkPlugin": "azure",
+        "containerRuntime": "containerd",
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.5.4/containerd-1.5.4-windows-amd64.tar.gz"
       }
     },
     "masterProfile": {
@@ -68,8 +71,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2101",
+      "imageVersion": "17763.1637.210111"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_22_serial.json
+++ b/job-templates/kubernetes_containerd_1_22_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.22",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -49,8 +49,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414",
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716",
       "windowsRuntimes": {
         "default": "hyperv",
         "hypervRuntimes": [

--- a/job-templates/kubernetes_containerd_master-hostprocess.json
+++ b/job-templates/kubernetes_containerd_master-hostprocess.json
@@ -51,8 +51,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_master-hostprocess.json
+++ b/job-templates/kubernetes_containerd_master-hostprocess.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
           "--feature-gates": "WindowsHostProcessContainers=true"

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -50,8 +50,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -72,8 +72,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_nightly.json
+++ b/job-templates/kubernetes_containerd_nightly.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
         },

--- a/job-templates/kubernetes_containerd_nightly.json
+++ b/job-templates/kubernetes_containerd_nightly.json
@@ -50,8 +50,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_19.json
+++ b/job-templates/kubernetes_release_1_19.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_1_19.json
+++ b/job-templates/kubernetes_release_1_19.json
@@ -46,8 +46,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_19_serial.json
+++ b/job-templates/kubernetes_release_1_19_serial.json
@@ -68,8 +68,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_19_serial.json
+++ b/job-templates/kubernetes_release_1_19_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.19",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_1_20.json
+++ b/job-templates/kubernetes_release_1_20.json
@@ -46,8 +46,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_20.json
+++ b/job-templates/kubernetes_release_1_20.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.20",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_1_20_serial.json
+++ b/job-templates/kubernetes_release_1_20_serial.json
@@ -68,8 +68,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_21.json
+++ b/job-templates/kubernetes_release_1_21.json
@@ -46,8 +46,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_21.json
+++ b/job-templates/kubernetes_release_1_21.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.21",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_1_21_serial.json
+++ b/job-templates/kubernetes_release_1_21_serial.json
@@ -68,8 +68,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_21_serial.json
+++ b/job-templates/kubernetes_release_1_21_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.21",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -46,8 +46,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -6,7 +6,7 @@
     },
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.17",
+      "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -68,8 +68,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2104",
-      "imageVersion": "17763.1879.210414"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -9,8 +9,8 @@
       "orchestratorRelease": "1.17",
       "kubernetesConfig": {
         "useManagedIdentity": false,
-        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-linux-amd64-v1.4.4.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.4/azure-vnet-cni-windows-amd64-v1.4.4.zip",
+        "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
         },

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -6,7 +6,7 @@
     },
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.17",
+      "orchestratorRelease": "",
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",


### PR DESCRIPTION
Updates:
- azure cni (has fix for [500ms startup time improvement](https://github.com/Azure/azure-container-networking/pull/966))
- update Windows vhds
- adds 1.22 job templates and removes 1.18 (only containerd 1.22 job templates- capz jobs have been added for 1.22)

/sig windows
/cc @marosset @chewong 