### PR TITLE
Add autoscaling v2 features to apiserver

### DIFF
--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -12,7 +12,11 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
+          "--feature-gates": "HPAContainerMetrics=true",
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "cloudControllerManagerConfig":{
+          "--feature-gates": "HPAContainerMetrics=true"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -10,12 +10,16 @@
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
-        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
+        "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip", 
+        "apiServerConfig": {
+          "--feature-gates": "HPAContainerMetrics=true",
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "cloudControllerManagerConfig":{
+          "--feature-gates": "HPAContainerMetrics=true"
+        },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"
-        },
-        "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },


### PR DESCRIPTION
The new hpa tests are failing: https://github.com/kubernetes/kubernetes/issues/104427

according to https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling/2702-graduate-hpa-api-to-GA#feature-enablement-and-rollback:

> The feature can be enabled by adding autoscaling/v2 to the --runtime-config flag: https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go#L45

/sig windows
