### PR TITLE
Don't explicity enable old apis for api server

### DIFF
--- a/job-templates/kubernetes_2004_containerd.json
+++ b/job-templates/kubernetes_2004_containerd.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_2004_master.json
+++ b/job-templates/kubernetes_2004_master.json
@@ -10,7 +10,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_20h2_master.json
+++ b/job-templates/kubernetes_20h2_master.json
@@ -7,7 +7,7 @@
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_1_19.json
+++ b/job-templates/kubernetes_containerd_1_19.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_1_19_serial.json
+++ b/job-templates/kubernetes_containerd_1_19_serial.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_1_20.json
+++ b/job-templates/kubernetes_containerd_1_20.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_1_20_serial.json
+++ b/job-templates/kubernetes_containerd_1_20_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_1_21.json
+++ b/job-templates/kubernetes_containerd_1_21.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_1_21_serial.json
+++ b/job-templates/kubernetes_containerd_1_21_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_1_22.json
+++ b/job-templates/kubernetes_containerd_1_22.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_1_22_serial.json
+++ b/job-templates/kubernetes_containerd_1_22_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_master-hostprocess.json
+++ b/job-templates/kubernetes_containerd_master-hostprocess.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true",
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true",
           "--feature-gates": "WindowsHostProcessContainers=true"
         },
         "kubeletConfig": {

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_nightly.json
+++ b/job-templates/kubernetes_containerd_nightly.json
@@ -12,7 +12,7 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-linux-amd64-v1.4.9.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.9/azure-vnet-cni-windows-amd64-v1.4.9.zip",
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_docker_gpu_master.json
+++ b/job-templates/kubernetes_docker_gpu_master.json
@@ -10,7 +10,7 @@
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"

--- a/job-templates/kubernetes_release_1_19.json
+++ b/job-templates/kubernetes_release_1_19.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_1_19_serial.json
+++ b/job-templates/kubernetes_release_1_19_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_1_20.json
+++ b/job-templates/kubernetes_release_1_20.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_1_20_serial.json
+++ b/job-templates/kubernetes_release_1_20_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_1_21.json
+++ b/job-templates/kubernetes_release_1_21.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_1_21_serial.json
+++ b/job-templates/kubernetes_release_1_21_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -15,7 +15,7 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -15,7 +15,7 @@
           "--feature-gates": "KubeletPodResources=false"
         },
         "apiServerConfig": {
-          "--runtime-config": "extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
+          "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         }
       }
     },


### PR DESCRIPTION
In #278  we noticed these api all have V1 versions available.  This removes them from the job specs.

/sig windows
/assign @marosset 