### PR TITLE
enable csi drivers for in-tree driver test config

### DIFF
--- a/job-templates/kubernetes_in_tree_volume_plugins_csi_enabled.json
+++ b/job-templates/kubernetes_in_tree_volume_plugins_csi_enabled.json
@@ -1,0 +1,63 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "featureFlags": {
+            "enableTelemetry": true
+        },
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "",
+            "kubernetesConfig": {
+                "useManagedIdentity": false,
+                "addons": [
+                    {
+                        "name": "azuredisk-csi-driver",
+                        "enabled": true
+                    },
+                    {
+                        "name": "azurefile-csi-driver",
+                        "enabled": true
+                    }
+                ]
+            }
+        },
+        "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "",
+            "vmSize": "Standard_D2_v3"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "windowspool1",
+                "count": 2,
+                "vmSize": "Standard_D2s_v3",
+                "osDiskSizeGB": 128,
+                "availabilityProfile": "AvailabilitySet",
+                "osType": "Windows"
+            }
+        ],
+        "windowsProfile": {
+            "adminUsername": "azureuser",
+            "adminPassword": "replacepassword1234$",
+            "sshEnabled": true,
+            "windowsPublisher": "microsoft-aks",
+            "windowsOffer": "aks-windows",
+            "windowsSku": "2019-datacenter-core-smalldisk-2104",
+            "imageVersion": "17763.1879.210414"
+        },
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": ""
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientID": "",
+            "secret": ""
+        }
+    }
+}


### PR DESCRIPTION
related to https://github.com/kubernetes/kubernetes/pull/104670, we will enable csi migration on k8s 1.23, need to enable csi drivers by default