### PR TITLE
images: use k8s.gcr.io/e2e-test-images

### DIFF
--- a/images/MirrorUpstreamK8sImgs.ps1
+++ b/images/MirrorUpstreamK8sImgs.ps1
@@ -68,7 +68,7 @@ function ManifestList
     (
         $Name,
         $Versions = "1.0",
-        $LinuxImageUpstreamK8sRepo = "gcr.io/kubernetes-e2e-test-images",
+        $LinuxImageUpstreamK8sRepo = "k8s.gcr.io/e2e-test-images",
         $LinuxImageSuffix = "-amd64",
         $Mirror = $true
     )


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1522

gcr.io/kubernetes-e2e-test-images is deprecated and hasn't received new
image updates in quite some time