### PR TITLE
Revert "enabling accelerated networking for staging cluster definitions"

### DIFF
--- a/job-templates/kubernetes_containerd_nightly.json
+++ b/job-templates/kubernetes_containerd_nightly.json
@@ -38,11 +38,10 @@
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D4s_v3",
+        "vmSize": "Standard_D2s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
-        "osType": "Windows",
-        "acceleratedNetworkingEnabledWindows": true
+        "osType": "Windows"
       }
     ],
     "windowsProfile": {
@@ -52,8 +51,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2109",
-      "imageVersion": "17763.2213.210927"
+      "windowsSku": "2019-datacenter-core-ctrd-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -34,11 +34,10 @@
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D4s_v3",
+        "vmSize": "Standard_D2s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
-        "osType": "Windows",
-        "acceleratedNetworkingEnabledWindows": true
+        "osType": "Windows"
       }
     ],
     "windowsProfile": {
@@ -47,8 +46,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2109",
-      "imageVersion": "17763.2213.210927"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -55,11 +55,10 @@
       {
         "name": "windowsgmsa",
         "count": 1,
-        "vmSize": "Standard_D4s_v3",
+        "vmSize": "Standard_D2s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",
-        "acceleratedNetworkingEnabledWindows": true,
         "extensions": [
           {
             "name": "gmsa-dc"
@@ -73,8 +72,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2109",
-      "imageVersion": "17763.2213.210927"
+      "windowsSku": "2019-datacenter-core-smalldisk-2107",
+      "imageVersion": "17763.2061.210716"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
Reverts kubernetes-sigs/windows-testing#291

we need to update https://github.com/kubernetes/test-infra/blob/master/kubetest/aksengine_helpers.go#L88 so the serialization/deserialization that happens in the prow jobs knows about the field.

Will revert this revert once those changes are made.