### PR TITLE
Revert "Revert "enabling accelerated networking for staging cluster definitions""

### DIFF
--- a/job-templates/kubernetes_containerd_nightly.json
+++ b/job-templates/kubernetes_containerd_nightly.json
@@ -38,10 +38,11 @@
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D2s_v3",
+        "vmSize": "Standard_D4s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
-        "osType": "Windows"
+        "osType": "Windows",
+        "acceleratedNetworkingEnabledWindows": true
       }
     ],
     "windowsProfile": {
@@ -51,8 +52,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2107",
-      "imageVersion": "17763.2061.210716"
+      "windowsSku": "2019-datacenter-core-ctrd-2109",
+      "imageVersion": "17763.2213.210927"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging.json
+++ b/job-templates/kubernetes_release_staging.json
@@ -34,10 +34,11 @@
       {
         "name": "windowspool1",
         "count": 2,
-        "vmSize": "Standard_D2s_v3",
+        "vmSize": "Standard_D4s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
-        "osType": "Windows"
+        "osType": "Windows",
+        "acceleratedNetworkingEnabledWindows": true
       }
     ],
     "windowsProfile": {
@@ -46,8 +47,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2107",
-      "imageVersion": "17763.2061.210716"
+      "windowsSku": "2019-datacenter-core-smalldisk-2109",
+      "imageVersion": "17763.2213.210927"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_staging_serial.json
+++ b/job-templates/kubernetes_release_staging_serial.json
@@ -55,10 +55,11 @@
       {
         "name": "windowsgmsa",
         "count": 1,
-        "vmSize": "Standard_D2s_v3",
+        "vmSize": "Standard_D4s_v3",
         "osDiskSizeGB": 128,
         "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",
+        "acceleratedNetworkingEnabledWindows": true,
         "extensions": [
           {
             "name": "gmsa-dc"
@@ -72,8 +73,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2107",
-      "imageVersion": "17763.2061.210716"
+      "windowsSku": "2019-datacenter-core-smalldisk-2109",
+      "imageVersion": "17763.2213.210927"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
Reverts kubernetes-sigs/windows-testing#292

This should be safe to commit again since https://github.com/kubernetes/test-infra/pull/24310 merged.