### PR TITLE
Revert "not enable CSI driver addon in aks-engine tests"

### DIFF
--- a/job-templates/kubernetes_containerd_csi_proxy.json
+++ b/job-templates/kubernetes_containerd_csi_proxy.json
@@ -14,11 +14,11 @@
                 "addons": [
                     {
                         "name": "azuredisk-csi-driver",
-                        "enabled": false
+                        "enabled": true
                     },
                     {
                         "name": "azurefile-csi-driver",
-                        "enabled": false
+                        "enabled": true
                     }
                 ]
             }


### PR DESCRIPTION
Reverts kubernetes-sigs/windows-testing#301