### PR TITLE
Use latest containerd 1.6 for 1.23+

### DIFF
--- a/job-templates/kubernetes_containerd_1_23.json
+++ b/job-templates/kubernetes_containerd_1_23.json
@@ -19,7 +19,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-1.6.0-beta.3-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/containerd-1.6.0-beta.4-windows-amd64.tar.gz"
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_containerd_1_23_serial.json
+++ b/job-templates/kubernetes_containerd_1_23_serial.json
@@ -19,7 +19,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-1.6.0-beta.3-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/containerd-1.6.0-beta.4-windows-amd64.tar.gz"
       }
     },
     "masterProfile": {

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -23,7 +23,7 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.5.8/containerd-1.5.8-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/containerd-1.6.0-beta.4-windows-amd64.tar.gz"
       }
     },
     "masterProfile": {


### PR DESCRIPTION
Hostprocess is on by default with 1.23+ so we should use the release that supports it