### PR TITLE
Use etcd image from k8s.gcr.io

### DIFF
--- a/images/image-repo-list-pr
+++ b/images/image-repo-list-pr
@@ -1,2 +1,1 @@
-gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
 privateRegistry: e2eteam


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Use etcd images from k8s.gcr.io

/hold 
until etcd:3.5.1-1 is promoted