### PR TITLE
Add feature flag so HPA scale tests pass in 1.23 jobs

### DIFF
--- a/job-templates/kubernetes_containerd_1_23_serial.json
+++ b/job-templates/kubernetes_containerd_1_23_serial.json
@@ -15,7 +15,11 @@
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "apiServerConfig": {
+          "--feature-gates": "HPAContainerMetrics=true",
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "cloudControllerManagerConfig":{
+          "--feature-gates": "HPAContainerMetrics=true"
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",


### PR DESCRIPTION
The HPA scale resource tests are failing: https://testgrid.k8s.io/sig-windows-1.23-release#aks-engine-windows-containerd-serial-slow-1.23

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-23-windows-containerd-serial-slow/1479248775422676992

```
Message: "HorizontalPodAutoscaler.autoscaling \"rs\" is invalid: spec.metrics[0].containerResource: Required value: must populate information for the given metric source (only allowed when HPAContainerMetrics feature is enabled)",
```

We dropped this flag when creating the new job templates.  This re-adds the flag

/sig windows
/assign @marosset 