### PR TITLE
Fix 20h2 tests

### DIFF
--- a/job-templates/kubernetes_20h2_master.json
+++ b/job-templates/kubernetes_20h2_master.json
@@ -9,13 +9,17 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.13/azure-vnet-cni-linux-amd64-v1.4.13.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.13/azure-vnet-cni-windows-amd64-v1.4.13.zip",
         "apiServerConfig": {
+          "--feature-gates": "HPAContainerMetrics=true",
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "cloudControllerManagerConfig":{
+          "--feature-gates": "HPAContainerMetrics=true"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.5.8/containerd-1.5.8-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/containerd-1.6.0-beta.4-windows-amd64.tar.gz"
       }
     },
     "masterProfile": {


### PR DESCRIPTION
The 20h2 tests are failing since we enabled HPC tests by default as well as the HPA tests:

https://testgrid.k8s.io/sig-windows-sac#aks-engine-windows-20h2-containerd-serial-slow-master

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-master-windows-20h2-containerd-serial-slow/1480302142475472896
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-master-windows-20h2-containerd/1480312460958240768

/sig windows
/assign @marosset 