### PR TITLE
enable azure disk csi driver on 1.23 template

### DIFF
--- a/job-templates/kubernetes_containerd_1_23.json
+++ b/job-templates/kubernetes_containerd_1_23.json
@@ -19,7 +19,13 @@
         },
         "networkPlugin": "azure",
         "containerRuntime": "containerd",
-        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/containerd-1.6.0-beta.4-windows-amd64.tar.gz"
+        "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/containerd-1.6.0-beta.4-windows-amd64.tar.gz",
+        "addons": [
+             {
+                "name": "azuredisk-csi-driver",
+                "enabled": true
+             }
+          ]
       }
     },
     "masterProfile": {
@@ -50,7 +56,8 @@
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
       "windowsSku": "2019-datacenter-core-ctrd-2107",
-      "imageVersion": "17763.2061.210716"
+      "imageVersion": "17763.2061.210716",
+      "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz",
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
azure disk csi migration is already enabled by default on k8s 1.23