### PR TITLE
enable azure disk csi driver on Windows cluster

### DIFF
--- a/job-templates/kubernetes_containerd_1_23.json
+++ b/job-templates/kubernetes_containerd_1_23.json
@@ -57,7 +57,8 @@
       "windowsOffer": "aks-windows",
       "windowsSku": "2019-datacenter-core-ctrd-2107",
       "imageVersion": "17763.2061.210716",
-      "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz",
+      "enableCSIProxy": true,
+      "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_in_tree_volume_plugins.json
+++ b/job-templates/kubernetes_in_tree_volume_plugins.json
@@ -8,7 +8,13 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "",
             "kubernetesConfig": {
-                "useManagedIdentity": false
+                "useManagedIdentity": false,
+                 "addons": [
+                     {
+                        "name": "azuredisk-csi-driver",
+                        "enabled": true
+                     }
+                  ]
             }
         },
         "masterProfile": {
@@ -33,6 +39,8 @@
             "windowsPublisher": "microsoft-aks",
             "windowsOffer": "aks-windows",
             "windowsSku": "2019-datacenter-core-smalldisk-2104",
+            "enableCSIProxy": true,
+            "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz",
             "imageVersion": "17763.1879.210414"
         },
         "linuxProfile": {


### PR DESCRIPTION
azure disk csi migration is already enabled by default from k8s 1.23