### PR TITLE
Disabling LegacyServiceAccountTokenNoAutoGeneration as mitigation to unblock windows testing on aks-engine

### DIFF
--- a/job-templates/kubernetes_20h2_master.json
+++ b/job-templates/kubernetes_20h2_master.json
@@ -13,7 +13,7 @@
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "cloudControllerManagerConfig":{
-          "--feature-gates": "HPAContainerMetrics=true"
+          "--feature-gates": "HPAContainerMetrics=true,LegacyServiceAccountTokenNoAutoGeneration=false"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -16,7 +16,7 @@
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "cloudControllerManagerConfig":{
-          "--feature-gates": "HPAContainerMetrics=true"
+          "--feature-gates": "HPAContainerMetrics=true,LegacyServiceAccountTokenNoAutoGeneration=false"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_master_csi_enabled.json
+++ b/job-templates/kubernetes_containerd_master_csi_enabled.json
@@ -13,6 +13,9 @@
                 "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.13/azure-vnet-cni-windows-amd64-v1.4.13.zip",
                 "networkPlugin": "azure",
                 "containerRuntime": "containerd",
+                "controllerManagerConfig": {
+                    "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
+                },
                 "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-windows-amd64.tar.gz",
                 "addons": [
                     {

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -16,7 +16,7 @@
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "cloudControllerManagerConfig":{
-          "--feature-gates": "HPAContainerMetrics=true"
+          "--feature-gates": "HPAContainerMetrics=true,LegacyServiceAccountTokenNoAutoGeneration=false"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_nightly.json
+++ b/job-templates/kubernetes_containerd_nightly.json
@@ -15,6 +15,9 @@
           "--feature-gates": "WindowsHostProcessContainers=true",
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
+        "controllerManagerConfig": {
+          "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
+        },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false,WindowsHostProcessContainers=true"
         },


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Some Windows tests are still using aks-engine which likely needs to be updated to support having legacy service account token auto generation disabled.
This PR reverts SA token generation to previous behavior.

x-ref: https://github.com/kubernetes/enhancements/pull/2800/files