### PR TITLE
Fixing LegacyServiceAccountTokenNoAutoGeneration feature gate flags in some configs

### DIFF
--- a/job-templates/kubernetes_20h2_master.json
+++ b/job-templates/kubernetes_20h2_master.json
@@ -13,7 +13,10 @@
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "cloudControllerManagerConfig":{
-          "--feature-gates": "HPAContainerMetrics=true,LegacyServiceAccountTokenNoAutoGeneration=false"
+          "--feature-gates": "HPAContainerMetrics=true"
+        },
+        "controllerManagerConfig": {
+          "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_master.json
+++ b/job-templates/kubernetes_containerd_master.json
@@ -16,7 +16,10 @@
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "cloudControllerManagerConfig":{
-          "--feature-gates": "HPAContainerMetrics=true,LegacyServiceAccountTokenNoAutoGeneration=false"
+          "--feature-gates": "HPAContainerMetrics=true"
+        },
+        "controllerManagerConfig": {
+          "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
         },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"

--- a/job-templates/kubernetes_containerd_master_serial.json
+++ b/job-templates/kubernetes_containerd_master_serial.json
@@ -16,7 +16,10 @@
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
         "cloudControllerManagerConfig":{
-          "--feature-gates": "HPAContainerMetrics=true,LegacyServiceAccountTokenNoAutoGeneration=false"
+          "--feature-gates": "HPAContainerMetrics=true"
+        },
+        "controllerManagerConfig": {
+          "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
         },
         "kubeletConfig": {
           "--feature-gates": "KubeletPodResources=false"


### PR DESCRIPTION

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

LegacyServiceAccountTokenNoAutoGeneration feature gate should be set for controller-manager, not cloud-controller-manager.

Fixes issues introduced by #312 