### PR TITLE
Adds LegacyServiceAccountTokenNoAutoGeneration=false feature gate

### DIFF
--- a/job-templates/kubernetes_containerd_csi_proxy.json
+++ b/job-templates/kubernetes_containerd_csi_proxy.json
@@ -9,6 +9,9 @@
             "orchestratorRelease": "",
             "kubernetesConfig": {
                 "useManagedIdentity": false,
+		"controllerManagerConfig": {
+                    "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
+                },
                 "containerRuntime": "containerd",
                 "windowsContainerdURL": "https://github.com/containerd/containerd/releases/download/v1.5.8/containerd-1.5.8-windows-amd64.tar.gz",
                 "addons": [

--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -14,6 +14,9 @@
         "apiServerConfig": {
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
         },
+        "controllerManagerConfig": {
+          "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
+        },
         "kubeletConfig": {
           "--feature-gates": "ExecProbeTimeout=true,KubeletPodResources=false"
         },


### PR DESCRIPTION
This PR reverts SA token generation to previous behavior.

Addresses the failures of the following jobs:

```
ci-kubernetes-e2e-azure-file-windows-containerd
ci-kubernetes-e2e-azure-disk-windows-containerd
ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hyperv-serial-slow
ci-kubernetes-e2e-aks-engine-azure-master-windows-containerd-hyperv
```

Ref: https://github.com/kubernetes-sigs/windows-testing/pull/312