### PR TITLE
Enables HPAContainerMetrics for Hyper-V runs

### DIFF
--- a/job-templates/kubernetes_containerd_hyperv.json
+++ b/job-templates/kubernetes_containerd_hyperv.json
@@ -12,7 +12,11 @@
         "azureCNIURLLinux": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.13/azure-vnet-cni-linux-amd64-v1.4.13.tgz",
         "azureCNIURLWindows": "https://github.com/Azure/azure-container-networking/releases/download/v1.4.13/azure-vnet-cni-windows-amd64-v1.4.13.zip",
         "apiServerConfig": {
+          "--feature-gates": "HPAContainerMetrics=true",
           "--runtime-config": "extensions/v1beta1/podsecuritypolicies=true"
+        },
+        "cloudControllerManagerConfig":{
+          "--feature-gates": "HPAContainerMetrics=true"
         },
         "controllerManagerConfig": {
           "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"


### PR DESCRIPTION
Currently, the HPA tests are failing in the ``aks-engine-windows-containerd-hyperv-serial-slow-master`` because this feature is not enabled.

x-ref: https://github.com/kubernetes/kubernetes/issues/109521