### PR TITLE
Update Repo lists 

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -8,6 +8,8 @@ Currently, for Windows jobs, we override the test image registry by defining the
 
 | Kubernetes Branch | Windows OS Version | Image Repository List                                                                                  |
 |-------------------|--------------------|--------------------------------------------------------------------------------------------------------|
-| *                 | 2004               | https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-2004   |
-| >= release-1.21 and master            | *                  | https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master |
-| < release-1.21      | *                  | https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list        |
+| >= release-1.21 and <= release-1.24            | *                  | https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list |
+| >= release-1.25        | WS 2022 or WS 2019    | https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-private-registry |
+| >= release-1.25        | WS 2019              | none - can use the image-repo-list-private-registry or non for ws 2019  |
+
+The private image repository doesn't have a way to promote images: https://github.com/kubernetes/k8s.io/pull/1929. We don't have a Windows Server 2022 image in the `gcr.io/authenticated-image-pulling` and use the `e2eprivate` dockerhub repository instead which allows sig-windows to update images for new Server versions.

--- a/images/image-repo-list
+++ b/images/image-repo-list
@@ -1,7 +1,3 @@
-dockerLibraryRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-e2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-promoterE2eRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-etcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-gcRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-PrivateRegistry: e2eteam
-sampleRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+gcAuthenticatedRegistry: e2eprivate
+gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+privateRegistry: e2eteam

--- a/images/image-repo-list-2004
+++ b/images/image-repo-list-2004
@@ -1,3 +1,0 @@
-gcAuthenticatedRegistry: e2eprivate
-gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-privateRegistry: e2eteam

--- a/images/image-repo-list-master
+++ b/images/image-repo-list-master
@@ -1,3 +1,0 @@
-gcAuthenticatedRegistry: e2eprivate
-gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
-privateRegistry: e2eteam


### PR DESCRIPTION
Updates:

- drops the repo list for WS2004 which is EOL.  
- Starting in 1.25 the only repo list required is `gcr.io/authenticated-image-pulling` for the private image used in the test `Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]` with  Windows server 2022.  
- drops the repo-list used for < 1.21