### PR TITLE
Remove healthcheck which is causing issues

### DIFF
--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -214,9 +214,6 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-2}
   selector: {}
   template:
-    metadata:
-      labels:
-        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -339,26 +336,6 @@ spec:
         name: capi
         sshAuthorizedKeys:
         - ${AZURE_SSH_PUBLIC_KEY:=""}
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: ${CLUSTER_NAME}-mhc-windows
-  namespace: default
-spec:
-  clusterName: ${CLUSTER_NAME}
-  maxUnhealthy: 100%
-  nodeStartupTimeout: 10m
-  selector:
-    matchLabels:
-      windows-healthcheck: "true"
-  unhealthyConditions:
-  - status: "false"
-    timeout: 300s
-    type: Ready
-  - status: Unknown
-    timeout: 300s
-    type: Ready
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity


### PR DESCRIPTION
In the most recent run https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-2022/1542246779368509440 the health check triggered right when the node was being created, This caused the node to be marked for deletion and the tests to hang.

there is a new image being published with an updated cloudbase-init package where this shouldn't be needed.