### PR TITLE
Add the needed feature-gates

### DIFF
--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -62,7 +62,7 @@ spec:
         extraArgs:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
-          feature-gates: ${K8S_FEATURE_GATES:-""}
+          feature-gates: WindowsHostProcessContainers=true
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json
@@ -321,7 +321,7 @@ spec:
             azure-container-registry-config: c:/k/azure.json
             cloud-config: c:/k/azure.json
             cloud-provider: azure
-            feature-gates: WindowsHostProcessContainers=true
+            feature-gates: WindowsHostProcessContainers=true,HPAContainerMetrics=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'


### PR DESCRIPTION
https://testgrid.k8s.io/sig-windows-master-release#capz-windows-containerd-2022-master-serial-slow is failing with

```
                       Type: "FieldValueRequired",
                        Message: "Required value: must populate information for the given metric source (only allowed when HPAContainerMetrics feature is enabled)",
                        Field: "spec.metrics[0].containerResource",
```

/sig windows
/assign @marosset 