### PR TITLE
fix timeout for ginkgo v2

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -131,6 +131,7 @@ run_e2e_test() {
             --ginkgo.slowSpecThreshold=120.0 \
             --ginkgo.flakeAttempts=0 \
             --ginkgo.trace=true \
+            --ginkgo.timeout=24h \
             --num-nodes="$WINDOWS_WORKER_MACHINE_COUNT" \
             --ginkgo.v=true \
             --dump-logs-on-failure=true \


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

Fixes the WS2022 jobs that were timeout at 1hr: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows-2022-serial-slow/1550272043243540480

```
      test/e2e/e2e_test.go:142
  << End Captured GinkgoWriter Output

  Interrupted by Timeout

  Here's a stack trace of all running goroutines:
    goroutine 79 [running]:
```

from https://github.com/kubernetes/kubernetes/pull/109111: `ACTION REQUIRED: When running test/e2e via the Ginkgo CLI, the v2 CLI must be used and `-timeout=24h` (or some other, suitable value) must be passed because the default timeout was reduced from 24h to 1h. When running it via `go test`, the corresponding `-args` parameter is `-ginkgo.timeout=24h`. To build the CLI in the Kubernetes repo, use `make all WHAT=github.com/onsi/ginkgo/v2/ginkgo`.`

https://github.com/kubernetes/kubernetes/pull/109111/files#diff-79eb656c28be03ab1500e09da2b99698eb9830d84cbdcd60c5f428b69f6bf4bb

/sig windows
/assign @marosset 