### PR TITLE
Revert "run cmd/kubeadm/test: add env KUBEADM_PATH and build kubeadm.exe"

### DIFF
--- a/build/build-windows-k8s.sh
+++ b/build/build-windows-k8s.sh
@@ -46,19 +46,12 @@ build_kubectl() {
 	cp ${GOPATH}/src/k8s.io/kubernetes/_output/dockerized/bin/windows/amd64/kubectl.exe ${DIST_DIR}
 }
 
-build_kubeadm() {
-	echo "building kubeadm.exe..."
-	$KUBEPATH/build/run.sh make WHAT=cmd/kubeadm KUBE_BUILD_PLATFORMS=windows/amd64 KUBE_VERBOSE=0
-	cp ${GOPATH}/src/k8s.io/kubernetes/_output/dockerized/bin/windows/amd64/kubeadm.exe ${DIST_DIR}
-}
-
 build_kube_binaries_for_upstream_e2e() {
 	$KUBEPATH/build/run.sh make WHAT=cmd/kubelet KUBE_BUILD_PLATFORMS=linux/amd64 KUBE_VERBOSE=0
 
 	build_kubelet
 	build_kubeproxy
 	build_kubectl
-	build_kubeadm
 }
 
 download_nssm() {

--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -12,7 +12,7 @@ $LocalPullBranch = "testBranch"
 $JUNIT_FILE_NAME="junit"
 $EXTRA_PACKAGES = @("./cmd/...")
 $EXCLUDED_PACKAGES = @("./pkg/proxy/...")
-$env:KUBEADM_PATH="./_output/dockerized/bin/windows/amd64/kubeadm.exe"
+
 
 function Prepare-TestPackages {
     Push-Location "$RepoPath/pkg"


### PR DESCRIPTION
The commit that is being reverted was meant to build the kubeadm binary, so it can be used to pass a few kubeadm-related unit tests. However, the modified script is for E2E tests, not unit tests. The commit is not doing what was intended, and it needlessly adds to the E2E job run times.

This reverts commit ac69bf750af1377f6ce31d79423f93bff9c5943c. (https://github.com/kubernetes-sigs/windows-testing/pull/345)

Related: https://github.com/kubernetes-sigs/windows-testing/issues/343