### PR TITLE
Adds --no-progress to choco

### DIFF
--- a/scripts/prepare_env_windows.ps1
+++ b/scripts/prepare_env_windows.ps1
@@ -13,10 +13,10 @@ $env:PATH+=";C:\ProgramData\chocolatey\bin"
 Write-Host "Install necessary packages"
 
 foreach ($package in $PACKAGES.Keys) {
-    $command = "choco.exe install $package --yes"
+    $command = "choco.exe install $package --yes --no-progress"
     $version = $PACKAGES[$package]
     if (-Not [string]::IsNullOrEmpty($version)) {
-        $command += " --version $version --limit-output"
+        $command += " --version $version"
     }
     Invoke-Expression $command
     if ( !$? ){


### PR DESCRIPTION
Currently, the unit tests job logs are filled with the download progression from choco install. We should trim them.