### PR TITLE
kube-proxy should be in kube-system

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -120,7 +120,7 @@ create_cluster(){
 apply_workload_configuraiton(){
     # A patch is needed to tell kube-proxy to use CI binaries.  This could go away once we have build scripts for kubeproxy HostProcess image.
     kubectl apply -f "${CAPZ_DIR}"/templates/test/ci/patches/windows-kubeproxy-ci.yaml
-    kubectl rollout restart ds -n calico-system kube-proxy-windows
+    kubectl rollout restart ds -n kube-system kube-proxy-windows
 
     # apply additional helper manifests (logger etc)
     kubectl apply -f "${CAPZ_DIR}"/templates/addons/windows/containerd-logging/containerd-logger.yaml


### PR DESCRIPTION
Once capz https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2931 merges we will need this update since kube-proxy will be in kube-system.