### PR TITLE
Updating Windows VHD used in aks-engine template to include 2022 11B updates

### DIFF
--- a/job-templates/kubernetes_containerd_1_23.json
+++ b/job-templates/kubernetes_containerd_1_23.json
@@ -55,8 +55,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2207",
-      "imageVersion": "17763.3232.220728",
+      "windowsSku": "2019-datacenter-core-ctrd-2212",
+      "imageVersion": "17763.3650.221213",
       "enableCSIProxy": true,
       "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz"
     },

--- a/job-templates/kubernetes_containerd_1_23_serial.json
+++ b/job-templates/kubernetes_containerd_1_23_serial.json
@@ -75,8 +75,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2207",
-      "imageVersion": "17763.3232.220728"
+      "windowsSku": "2019-datacenter-core-ctrd-2212",
+      "imageVersion": "17763.3650.221213"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_24.json
+++ b/job-templates/kubernetes_containerd_1_24.json
@@ -57,8 +57,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-ctrd-2207",
-      "imageVersion": "17763.3232.220728"
+      "windowsSku": "2019-datacenter-core-ctrd-2212",
+      "imageVersion": "17763.3650.221213"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/job-templates/kubernetes_containerd_1_24_csi_enabled.json
+++ b/job-templates/kubernetes_containerd_1_24_csi_enabled.json
@@ -51,8 +51,8 @@
             "enableCSIProxy": true,
             "windowsPublisher": "microsoft-aks",
             "windowsOffer": "aks-windows",
-            "windowsSku": "2019-datacenter-core-ctrd-2207",
-            "imageVersion": "17763.3232.220728"
+            "windowsSku": "2019-datacenter-core-ctrd-2212",
+            "imageVersion": "17763.3650.221213"
         },
         "linuxProfile": {
             "adminUsername": "azureuser",

--- a/job-templates/kubernetes_release_1_23.json
+++ b/job-templates/kubernetes_release_1_23.json
@@ -47,8 +47,8 @@
       "sshEnabled": true,
       "windowsPublisher": "microsoft-aks",
       "windowsOffer": "aks-windows",
-      "windowsSku": "2019-datacenter-core-smalldisk-2207",
-      "imageVersion": "17763.3232.220728"
+      "windowsSku": "2019-datacenter-core-smalldisk-2212",
+      "imageVersion": "17763.3650.221213"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",


### PR DESCRIPTION
These include some HNS fixes which should clean up the SIG-Windows test signal

Signed-off-by: Mark Rossetti <marosset@microsoft.com>