### PR TITLE
Update the pre-kubeadm script to work with < 1.25

### DIFF
--- a/capz/templates/gmsa.yaml
+++ b/capz/templates/gmsa.yaml
@@ -196,7 +196,7 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         # This test installs release packages or binaries that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
         # and finally uninstalls the packages.
@@ -208,16 +208,40 @@ spec:
           CI_DIR=/tmp/k8s-ci
           mkdir -p $$CI_DIR
           declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-
+          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+          CONTAINER_EXT="tar"
           echo "* testing CI version $$CI_VERSION"
-
-          CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-            wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
-            chmod +x "$$CI_DIR/$$CI_PACKAGE"
-            mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
-          done
+          # Check for semver
+          if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+            echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+            apt-get update
+            # replace . with \.
+            VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
+            PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+              DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
+            done
+          else
+            CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
+              chmod +x "$$CI_DIR/$$CI_PACKAGE"
+              mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
+            done
+            IMAGE_REGISTRY_PREFIX=registry.k8s.io
+            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+              echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+              wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+              $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+              $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+              $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+            done
+          fi
           systemctl restart kubelet
         fi
         echo "* checking binary versions"

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -196,7 +196,7 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         # This test installs release packages or binaries that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
         # and finally uninstalls the packages.
@@ -208,16 +208,40 @@ spec:
           CI_DIR=/tmp/k8s-ci
           mkdir -p $$CI_DIR
           declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-
+          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+          CONTAINER_EXT="tar"
           echo "* testing CI version $$CI_VERSION"
-
-          CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-            wget "$$CI_URL/$$CI_PACKAGE" -O "$$CI_DIR/$$CI_PACKAGE"
-            chmod +x "$$CI_DIR/$$CI_PACKAGE"
-            mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
-          done
+          # Check for semver
+          if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+            echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list
+            apt-get update
+            # replace . with \.
+            VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
+            PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+              DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
+            done
+          else
+            CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+              wget "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
+              chmod +x "$$CI_DIR/$$CI_PACKAGE"
+              mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
+            done
+            IMAGE_REGISTRY_PREFIX=registry.k8s.io
+            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+              echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+              wget "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+              $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+              $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+              $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+            done
+          fi
           systemctl restart kubelet
         fi
         echo "* checking binary versions"


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

There were a few changes to the kubernetes registry between 1.25 and 1.26. When the images are unpacked from the older versions the images that are unloaded don't contain the correct tag and therefor aren't found when they are pull by the name.  

There is a bit more information in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2398. The script is a copy of https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/207ff80443e55db9a7e3857fe51da46842e4b99e/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml from cluster-api-provider-azure