### PR TITLE
unit tests: Fixes kubeadm binary build

### DIFF
--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -79,9 +79,10 @@ function Build-Kubeadm {
         "-X 'k8s.io/component-base/version.gitCommit=6a61da26b6761d1b86844cdec194ccaa02b41f3'"
     )
 
+    Push-Location "$RepoPath"
     go build -ldflags "$buildFlags" -o kubeadm.exe .\cmd\kubeadm\
-    $curDir = [System.Environment]::CurrentDirectory
-    $env:KUBEADM_PATH = Join-Path $curDir "kubeadm.exe"
+    $env:KUBEADM_PATH = Join-Path "$RepoPath" "kubeadm.exe"
+    Pop-Location
 }
 
 function Run-K8sUnitTests {


### PR DESCRIPTION
Previously, we added the kubeadm binary building to the unit test script, as it is needed for a few of the kubeadm unit tests, however, the binary was not build correctly.