### PR TITLE
Replacing k8s.gcr.io refs with registry.k8s.io in k-sigs/windows-testing

### DIFF
--- a/gce/loadtest-prepull.yaml
+++ b/gce/loadtest-prepull.yaml
@@ -14,7 +14,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: windows
       containers:
-      - image: k8s.gcr.io/pause:3.4.1
+      - image: registry.k8s.io/pause:3.4.1
         name: pause
       - image: mcr.microsoft.com/windows/servercore/iis
         name: iis

--- a/gce/prepull-1.21.yaml
+++ b/gce/prepull-1.21.yaml
@@ -36,37 +36,37 @@ spec:
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
       containers:
-      - image: k8s.gcr.io/e2e-test-images/agnhost:2.26
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.26
         name: k8s-agnhost-226
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/echoserver:2.3
+      - image: registry.k8s.io/e2e-test-images/echoserver:2.3
         name: k8s-echoserver23
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.4
+      - image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.4
         name: k8s-jessie-dnsutils17-14
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/kitten:1.4
+      - image: registry.k8s.io/e2e-test-images/kitten:1.4
         name: k8s-kitten14
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nautilus:1.4
+      - image: registry.k8s.io/e2e-test-images/nautilus:1.4
         name: k8s-nautilus14
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/sample-apiserver:1.17.4
+      - image: registry.k8s.io/e2e-test-images/sample-apiserver:1.17.4
         name: k8s-sample-apiserver-1174
         resources:
           requests:

--- a/gce/prepull-1.22.yaml
+++ b/gce/prepull-1.22.yaml
@@ -36,73 +36,73 @@ spec:
       # run ping in each container to keep it alive so that kubernetes does not
       # continually restart the containers while we're prepulling.
       containers:
-      - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
         name: agnhost-232
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29-1
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-1
         name: busybox1
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/echoserver:2.3
+      - image: registry.k8s.io/e2e-test-images/echoserver:2.3
         name: echoserver23
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/httpd:2.4.38-1
+      - image: registry.k8s.io/e2e-test-images/httpd:2.4.38-1
         name: httpd-2438
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/httpd:2.4.39-1
+      - image: registry.k8s.io/e2e-test-images/httpd:2.4.39-1
         name: httpd-2439
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.4
+      - image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.4
         name: jessie-dnsutils14
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/kitten:1.4
+      - image: registry.k8s.io/e2e-test-images/kitten:1.4
         name: kitten14
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nautilus:1.4
+      - image: registry.k8s.io/e2e-test-images/nautilus:1.4
         name: nautilus14
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nginx:1.14-1
+      - image: registry.k8s.io/e2e-test-images/nginx:1.14-1
         name: nginx114
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nginx:1.15-1
+      - image: registry.k8s.io/e2e-test-images/nginx:1.15-1
         name: nginx115
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/pause:3.5
+      - image: registry.k8s.io/e2e-test-images/pause:3.5
         name: pause-35
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/sample-apiserver:1.17.4
+      - image: registry.k8s.io/e2e-test-images/sample-apiserver:1.17.4
         name: sample-apiserver-117
         resources:
           requests:

--- a/gce/prepull-head.yaml
+++ b/gce/prepull-head.yaml
@@ -43,73 +43,73 @@ spec:
       #
       #
       containers:
-      - image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.36
         name: agnhost-236
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29-2
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-2
         name: busybox1
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/echoserver:2.4
+      - image: registry.k8s.io/e2e-test-images/echoserver:2.4
         name: echoserver24
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/httpd:2.4.38-2
+      - image: registry.k8s.io/e2e-test-images/httpd:2.4.38-2
         name: httpd-2438
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/httpd:2.4.39-2
+      - image: registry.k8s.io/e2e-test-images/httpd:2.4.39-2
         name: httpd-2439
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.5
+      - image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.5
         name: jessie-dnsutils15
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/kitten:1.5
+      - image: registry.k8s.io/e2e-test-images/kitten:1.5
         name: kitten15
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nautilus:1.5
+      - image: registry.k8s.io/e2e-test-images/nautilus:1.5
         name: nautilus15
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nginx:1.14-2
+      - image: registry.k8s.io/e2e-test-images/nginx:1.14-2
         name: nginx114
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/nginx:1.15-2
+      - image: registry.k8s.io/e2e-test-images/nginx:1.15-2
         name: nginx115
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/pause:3.7
+      - image: registry.k8s.io/e2e-test-images/pause:3.7
         name: pause-37
         resources:
           requests:
             cpu: 1m
         command: ['cmd.exe', '/c', 'ping -n 1800 127.0.0.1 >NUL']
-      - image: k8s.gcr.io/e2e-test-images/sample-apiserver:1.17.5
+      - image: registry.k8s.io/e2e-test-images/sample-apiserver:1.17.5
         name: sample-apiserver-117
         resources:
           requests:

--- a/images/MirrorUpstreamK8sImgs.ps1
+++ b/images/MirrorUpstreamK8sImgs.ps1
@@ -68,7 +68,7 @@ function ManifestList
     (
         $Name,
         $Versions = "1.0",
-        $LinuxImageUpstreamK8sRepo = "k8s.gcr.io/e2e-test-images",
+        $LinuxImageUpstreamK8sRepo = "registry.k8s.io/e2e-test-images",
         $LinuxImageSuffix = "-amd64",
         $Mirror = $true
     )


### PR DESCRIPTION
/kind cleanup
/sig windows

Part of https://github.com/kubernetes/k8s.io/issues/4738

/assign @jsturtevant @claudiubelu @jayunit100 