### PR TITLE
unit tests: Updates golang to 1.20.2

### DIFF
--- a/scripts/prepare_env_windows.ps1
+++ b/scripts/prepare_env_windows.ps1
@@ -1,4 +1,4 @@
-$PACKAGES= @{ git = ""; golang = "1.19.0"; make = "" }
+$PACKAGES= @{ git = ""; golang = "1.20.2"; make = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
Kubernetes has switched to golang 1.20. Because of this, the unit tests runs have failures with the following note:

note: module requires Go 1.20

Updates the installed golang to 1.20.2

Sample job failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1635618795965911040