### PR TITLE
Add ability to skip log collection when running run-capz-e2e.sh locally

### DIFF
--- a/capz/gmsa/configuration/configure.go
+++ b/capz/gmsa/configuration/configure.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 )
 
-func Fail(message string, callerSkip ...int) {
+func Fail(message string, _ ...int) {
 	panic(message)
 }
 

--- a/capz/readme.md
+++ b/capz/readme.md
@@ -23,8 +23,9 @@ export AZURE_SSH_PUBLIC_KEY_FILE="$HOME/.ssh/id_rsa.pub"
 | ENV variable  | Description  |
 | ------------- | ------------ |
 | `SKIP_CREATE` | Don't create a cluster.  Must set `CLUSTER_NAME` and have current a workload cluster kubeconfig file with name `./"${CLUSTER_NAME}".kubeconfig` |
+| `SKIP_LOG_COLLECTION` | Don't collect logs from the cluster |
 | `SKIP_TEST`  | Only creates the cluster, will not run tests |
-| `SKIP_CLEANUP` | Don't delete the cluster / resource group deletion |
+| `SKIP_CLEANUP` | Don't delete the cluster / resource group after script executions |
 | `RUN_SERIAL_TESTS` | If set to `true` then serial slow tests will be run with default ginkgo settings |
 | `KUBERNETES_VERSION`  | Valid values are `latest` (default) and  `latest-1.x` where x is valid kubernetes minor version such as `latest-1.24` |
 | `AZURE_LOCATION` | The azure region to deploy resources into |


### PR DESCRIPTION
I have been running `run-capz-e2e.sh` locally a lot lately and don't need to wait for log collection so adding the ability to skip.

/assign @jsturtevant 