### PR TITLE
Updates the Windows image used for unit tests

### DIFF
--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -9,7 +9,7 @@ LOCAL_DIR=${BASH_SOURCE[0]}
 SSH_OPTS="-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 PROW_BUILD_ID="${BUILD_ID:-000000000000}"
 AZURE_RESOURCE_GROUP="win-unit-test-${PROW_BUILD_ID}"
-AZURE_DEFAULT_IMG="MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:20348.524.220201"
+AZURE_DEFAULT_IMG="MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
 AZURE_IMG="${WIN_VM_IMG:-$AZURE_DEFAULT_IMG}"
 VM_NAME="winTestVM"
 VM_LOCATION="${VM_LOCATION:-westus2}"


### PR DESCRIPTION
The current image is deprecated, resulting in failures:

```
ERROR: (ImageVersionDeprecated) VM Image from publisher: MicrosoftWindowsServer with - Offer: WindowsServer, Sku: 2022-datacenter-smalldisk-g2, Version: 20348.524.220201 is deprecated.
```

Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1643230608895250432