### PR TITLE
Removing references to WindowsHostProcessContainers feature-gate

### DIFF
--- a/capz/templates/gmsa.yaml
+++ b/capz/templates/gmsa.yaml
@@ -65,7 +65,7 @@ spec:
             azure-container-registry-config: c:/k/azure.json
             cloud-config: c:/k/azure.json
             cloud-provider: azure
-            feature-gates: WindowsHostProcessContainers=true,HPAContainerMetrics=true
+            feature-gates: HPAContainerMetrics=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -140,7 +140,7 @@ spec:
         extraArgs:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
-          feature-gates: WindowsHostProcessContainers=true,HPAContainerMetrics=true
+          feature-gates: HPAContainerMetrics=true
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -65,7 +65,7 @@ spec:
             azure-container-registry-config: c:/k/azure.json
             cloud-config: c:/k/azure.json
             cloud-provider: azure
-            feature-gates: WindowsHostProcessContainers=true,HPAContainerMetrics=true
+            feature-gates: HPAContainerMetrics=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -140,7 +140,7 @@ spec:
         extraArgs:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
-          feature-gates: WindowsHostProcessContainers=true,HPAContainerMetrics=true
+          feature-gates: HPAContainerMetrics=true
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json


### PR DESCRIPTION
WindowsHostProcessContainers was enabled by default in v1.23 and went stable in v1.26

https://github.com/kubernetes/kubernetes/pull/117570 removes the feature-gate

/sig windows
/assign @jsturtevant 