### PR TITLE
ensure SCRIPT_ROOT in run-capz-e2e.sh is an absolute path

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -4,7 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
+SCRIPT_ROOT=$(dirname "${SCRIPT_PATH}")
 export CAPZ_DIR="${CAPZ_DIR:-"${GOPATH}/src/sigs.k8s.io/cluster-api-provider-azure"}"
 : "${CAPZ_DIR:?Environment variable empty or not defined.}"
 if [[ ! -d $CAPZ_DIR ]]; then


### PR DESCRIPTION
/assign @jsturtevant 

The script changes directories to the capz dir so we need to make sure SCRIPT_ROOT is an absolute path so we can find the cluster templates