### PR TITLE
Adding a post-kubeadm action to write EnableLogQuery=true to kubelet config if needed

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -42,6 +42,15 @@ spec:
         path: C:/replace-containerd.ps1
         permissions: "0744"
       - content: |
+          $ErrorActionPreference = "Stop"
+          # Check if NodeLogQuery feature gate was specified for the cluster and if so, also enable it via kubelet config
+          $kubeletEnvContents = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+          if ($kubeletEnvContents.Contains("NodeLogQuery=true")) {
+              Add-Content -Path "$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml" -Value "EnableSystemLogQuery: true" -Encoding ascii
+          }
+        path: C:/NodeLogQueryKubeletConfig.ps1
+        permissions: "0744"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force
@@ -81,6 +90,7 @@ spec:
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
+      - powershell C:/NodeLogQueryKubeletConfig.ps1
       - nssm set kubelet start SERVICE_AUTO_START
       - powershell C:/defender-exclude-calico.ps1
       preKubeadmCommands:

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -42,6 +42,15 @@ spec:
         path: C:/replace-containerd.ps1
         permissions: "0744"
       - content: |
+          $ErrorActionPreference = "Stop"
+          # Check if NodeLogQuery feature gate was specified for the cluster and if so, also enable it via kubelet config
+          $kubeletEnvContents = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+          if ($kubeletEnvContents.Contains("NodeLogQuery=true")) {
+              Add-Content -Path "$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml" -Value "EnableSystemLogQuery: true" -Encoding ascii
+          }
+        path: C:/NodeLogQueryKubeletConfig.ps1
+        permissions: "0744"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force
@@ -81,6 +90,7 @@ spec:
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
+      - powershell C:/NodeLogQueryKubeletConfig.ps1
       - nssm set kubelet start SERVICE_AUTO_START
       - powershell C:/defender-exclude-calico.ps1
       preKubeadmCommands:

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -41,6 +41,15 @@ spec:
           containerd-shim-runhcs-v1.exe --version
         path: C:/replace-containerd.ps1
         permissions: "0744"
+      - content: |
+          $ErrorActionPreference = "Stop"
+          # Check if NodeLogQuery feature gate was specified for the cluster and if so, also enable it via kubelet config
+          $kubeletEnvContents = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+          if ($kubeletEnvContents.Contains("NodeLogQuery=true")) {
+              Add-Content -Path "$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml" -Value "EnableSystemLogQuery: true" -Encoding ascii
+          }
+        path: C:/NodeLogQueryKubeletConfig.ps1
+        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
@@ -53,6 +62,7 @@ spec:
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
+      - powershell C:/NodeLogQueryKubeletConfig.ps1
       - nssm set kubelet start SERVICE_AUTO_START
       - powershell C:/defender-exclude-calico.ps1
       preKubeadmCommands:

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -42,6 +42,15 @@ spec:
         path: C:/replace-containerd.ps1
         permissions: "0744"
       - content: |
+          $ErrorActionPreference = "Stop"
+          # Check if NodeLogQuery feature gate was specified for the cluster and if so, also enable it via kubelet config
+          $kubeletEnvContents = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+          if ($kubeletEnvContents.Contains("NodeLogQuery=true")) {
+              Add-Content -Path "$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml" -Value "EnableSystemLogQuery: true" -Encoding ascii
+          }
+        path: C:/NodeLogQueryKubeletConfig.ps1
+        permissions: "0744"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force
@@ -81,6 +90,7 @@ spec:
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
+      - powershell C:/NodeLogQueryKubeletConfig.ps1
       - nssm set kubelet start SERVICE_AUTO_START
       - powershell C:/defender-exclude-calico.ps1
       preKubeadmCommands:

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -42,6 +42,15 @@ spec:
         path: C:/replace-containerd.ps1
         permissions: "0744"
       - content: |
+          $ErrorActionPreference = "Stop"
+          # Check if NodeLogQuery feature gate was specified for the cluster and if so, also enable it via kubelet config
+          $kubeletEnvContents = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+          if ($kubeletEnvContents.Contains("NodeLogQuery=true")) {
+              Add-Content -Path "$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml" -Value "EnableSystemLogQuery: true" -Encoding ascii
+          }
+        path: C:/NodeLogQueryKubeletConfig.ps1
+        permissions: "0744"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force
@@ -81,6 +90,7 @@ spec:
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
+      - powershell C:/NodeLogQueryKubeletConfig.ps1
       - nssm set kubelet start SERVICE_AUTO_START
       - powershell C:/defender-exclude-calico.ps1
       preKubeadmCommands:


### PR DESCRIPTION
This PR enables use run run nodeLogQuery e2e tests in upstrate PROW jobs.

NodeLogQuery requires both a feature gate and a kubelet config value (in the conf file) to be set.

For test clusters where we want to enable this alpha feature we will update the `NODE_FEATURE_GATE` env var to include `NodeLogQuery=true` and then the new post-kubeadm action will inspect the feature gates used to start the kubelet and append the correct setting if needed

/sig windows
/assign @jsturtevant @aravindhp 