### PR TITLE
Updating control-plane os from Ubuntu 18.04 LTS to 22.04 LTS

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -367,7 +367,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -360,7 +360,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -272,7 +272,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -364,7 +364,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -357,7 +357,7 @@ spec:
         marketplace:
           offer: capi
           publisher: cncf-upstream
-          sku: ubuntu-1804-gen1
+          sku: ubuntu-2204-gen1
           version: latest
       osDisk:
         diskSizeGB: 128


### PR DESCRIPTION
/hold for CI jobs

Hopefully this will address some recent issues such with coredns not starting on the CP node for windows test passes