### PR TITLE
Adds set -x option for unit test script

### DIFF
--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
The unit test jobs are currently failing, seemingly before the ``az`` client is set up. We don't have a lot of information about what is happening in the script.

Setting the ``set -x`` option will at least log the parts of script that have run.