### PR TITLE
Adding logging into replace-containerd.ps1

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -33,6 +33,25 @@ spec:
             Stop-Service containerd -Force
             echo "downloading containerd: $$CONTAINERD_URL"
             curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            # Log service state and if any files under containerd director are locked
+            Get-Service -Name containerd, kubelet
+            $dir = "c:/Program Files/containerd"
+            $files = Get-ChildItem $dir -Recurse
+            Write-Output "Checking if any files under $dir are locked"
+            foreach ($file in $files) {
+                $f = $file.FullName
+                Write-output "$f"
+                $fi = New-Object System.IO.FileInfo $f
+                try {
+                    $fStream = $fi.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+                    if ($fStream) {
+                        $fStream.Close()
+                    }
+                } catch {
+                    Write-Output "Unable to open file: $f"
+                }
+            }
+            Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
 
             Start-Service containerd

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -33,6 +33,25 @@ spec:
             Stop-Service containerd -Force
             echo "downloading containerd: $$CONTAINERD_URL"
             curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            # Log service state and if any files under containerd director are locked
+            Get-Service -Name containerd, kubelet
+            $dir = "c:/Program Files/containerd"
+            $files = Get-ChildItem $dir -Recurse
+            Write-Output "Checking if any files under $dir are locked"
+            foreach ($file in $files) {
+                $f = $file.FullName
+                Write-output "$f"
+                $fi = New-Object System.IO.FileInfo $f
+                try {
+                    $fStream = $fi.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+                    if ($fStream) {
+                        $fStream.Close()
+                    }
+                } catch {
+                    Write-Output "Unable to open file: $f"
+                }
+            }
+            Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
 
             Start-Service containerd

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -33,6 +33,25 @@ spec:
             Stop-Service containerd -Force
             echo "downloading containerd: $$CONTAINERD_URL"
             curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            # Log service state and if any files under containerd director are locked
+            Get-Service -Name containerd, kubelet
+            $dir = "c:/Program Files/containerd"
+            $files = Get-ChildItem $dir -Recurse
+            Write-Output "Checking if any files under $dir are locked"
+            foreach ($file in $files) {
+                $f = $file.FullName
+                Write-output "$f"
+                $fi = New-Object System.IO.FileInfo $f
+                try {
+                    $fStream = $fi.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+                    if ($fStream) {
+                        $fStream.Close()
+                    }
+                } catch {
+                    Write-Output "Unable to open file: $f"
+                }
+            }
+            Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
 
             Start-Service containerd

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -33,6 +33,25 @@ spec:
             Stop-Service containerd -Force
             echo "downloading containerd: $$CONTAINERD_URL"
             curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            # Log service state and if any files under containerd director are locked
+            Get-Service -Name containerd, kubelet
+            $dir = "c:/Program Files/containerd"
+            $files = Get-ChildItem $dir -Recurse
+            Write-Output "Checking if any files under $dir are locked"
+            foreach ($file in $files) {
+                $f = $file.FullName
+                Write-output "$f"
+                $fi = New-Object System.IO.FileInfo $f
+                try {
+                    $fStream = $fi.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+                    if ($fStream) {
+                        $fStream.Close()
+                    }
+                } catch {
+                    Write-Output "Unable to open file: $f"
+                }
+            }
+            Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
 
             Start-Service containerd

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -33,6 +33,25 @@ spec:
             Stop-Service containerd -Force
             echo "downloading containerd: $$CONTAINERD_URL"
             curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            # Log service state and if any files under containerd director are locked
+            Get-Service -Name containerd, kubelet
+            $dir = "c:/Program Files/containerd"
+            $files = Get-ChildItem $dir -Recurse
+            Write-Output "Checking if any files under $dir are locked"
+            foreach ($file in $files) {
+                $f = $file.FullName
+                Write-output "$f"
+                $fi = New-Object System.IO.FileInfo $f
+                try {
+                    $fStream = $fi.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+                    if ($fStream) {
+                        $fStream.Close()
+                    }
+                } catch {
+                    Write-Output "Unable to open file: $f"
+                }
+            }
+            Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
 
             Start-Service containerd


### PR DESCRIPTION
Adding extra logging in replace-containerd.ps1 to see if any containerd files are locked during upgrade process

/hold