### PR TITLE
Fixing run-lint github workflows

### DIFF
--- a/.github/workflows/capz.yml
+++ b/.github/workflows/capz.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           version: latest
           working-directory: capz/gmsa/configuration
-          args: --build-tags=e2e --timeout=5m 
+          args: --build-tags=e2e --timeout=10m 
   build-gmsa-configuration:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/capz.yml
+++ b/.github/workflows/capz.yml
@@ -29,10 +29,11 @@ jobs:
     name: lint go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-      - uses: actions/checkout@v3
+          cache: false # workaround for golangci-lint caching issues https://github.com/golangci/golangci-lint-action/pull/704
       # run mod download prior to running linter to avoid timeouts while running linter
       - name: build go
         run: |

--- a/capz/gmsa/configuration/configure.go
+++ b/capz/gmsa/configuration/configure.go
@@ -236,6 +236,7 @@ func fileOnHost(path string) (*os.File, error) {
 	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 		return nil, err
 	}
+
 	return os.Create(path)
 }
 


### PR DESCRIPTION
Fixing go lint CI issues

I'm following recommendations from

https://github.com/golangci/golangci-lint-action/issues/677
and
https://github.com/golangci/golangci-lint-action/pull/704/files

/assign @jsturtevant 