### PR TITLE
Allow for setting kube-apiserver and kube-scheduler features gates for VPA tests

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -184,7 +184,7 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: HPAContainerMetrics=true
+          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
@@ -199,6 +199,9 @@ spec:
           extraArgs:
             quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
+      scheduler:
+        extraArgs:
+          feature-gates: ${SCHEDULER_FEATURE_GATES:-""}
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -182,7 +182,7 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: HPAContainerMetrics=true
+          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
@@ -197,6 +197,9 @@ spec:
           extraArgs:
             quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
+      scheduler:
+        extraArgs:
+          feature-gates: ${SCHEDULER_FEATURE_GATES:-""}
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -151,7 +151,7 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: HPAContainerMetrics=true
+          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
@@ -165,6 +165,9 @@ spec:
           dataDir: /var/lib/etcddisk/etcd
           extraArgs:
             quota-backend-bytes: "8589934592"
+      scheduler:
+        extraArgs:
+          feature-gates: ${SCHEDULER_FEATURE_GATES:-""}
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -184,7 +184,7 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: HPAContainerMetrics=true
+          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
@@ -199,6 +199,9 @@ spec:
           extraArgs:
             quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
+      scheduler:
+        extraArgs:
+          feature-gates: ${SCHEDULER_FEATURE_GATES:-""}
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -182,7 +182,7 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: HPAContainerMetrics=true
+          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
@@ -197,6 +197,9 @@ spec:
           extraArgs:
             quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
+      scheduler:
+        extraArgs:
+          feature-gates: ${SCHEDULER_FEATURE_GATES:-""}
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0


### PR DESCRIPTION
These are needed to get the VPA tests running in CAPZ created clusters in PROW

/assign @jsturtevant 