### PR TITLE
capz/templates: Allow enabling the NodeLogQuery feature

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -232,6 +232,20 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
+        if grep -q "NodeLogQuery=true" /var/lib/kubelet/kubeadm-flags.env; then
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+          echo "* adding enableSystemLogQuery: true to kubelet config"
+          printf "enableSystemLogQuery: true\n" | $${SUDO} tee --append /var/lib/kubelet/config.yaml
+          $${SUDO} systemctl restart kubelet
+        fi
+      owner: root:root
+      path: /tmp/node-log-query-kubelet-config.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         # This test installs release packages or binaries that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -306,7 +320,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
     - bash -c /tmp/kubeadm-bootstrap.sh
     useExperimentalRetryJoin: true

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -227,6 +227,20 @@ spec:
       permissions: "0644"
     - content: |
         #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        if grep -q "NodeLogQuery=true" /var/lib/kubelet/kubeadm-flags.env; then
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+          echo "* adding enableSystemLogQuery: true to kubelet config"
+          printf "enableSystemLogQuery: true\n" | $${SUDO} tee --append /var/lib/kubelet/config.yaml
+          $${SUDO} systemctl restart kubelet
+        fi
+      owner: root:root
+      path: /tmp/node-log-query-kubelet-config.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
 
         set -o nounset
         set -o pipefail
@@ -295,6 +309,7 @@ spec:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
     postKubeadmCommands:
+    - bash -c /tmp/node-log-query-kubelet-config.sh
     - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/replace-k8s-binaries.sh

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -194,6 +194,20 @@ spec:
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        if grep -q "NodeLogQuery=true" /var/lib/kubelet/kubeadm-flags.env; then
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+          echo "* adding enableSystemLogQuery: true to kubelet config"
+          printf "enableSystemLogQuery: true\n" | $${SUDO} tee --append /var/lib/kubelet/config.yaml
+          $${SUDO} systemctl restart kubelet
+        fi
+      owner: root:root
+      path: /tmp/node-log-query-kubelet-config.sh
+      permissions: "0744"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -211,7 +225,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands: []
     useExperimentalRetryJoin: true
   machineTemplate:

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -232,6 +232,20 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
+        if grep -q "NodeLogQuery=true" /var/lib/kubelet/kubeadm-flags.env; then
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+          echo "* adding enableSystemLogQuery: true to kubelet config"
+          printf "enableSystemLogQuery: true\n" | $${SUDO} tee --append /var/lib/kubelet/config.yaml
+          $${SUDO} systemctl restart kubelet
+        fi
+      owner: root:root
+      path: /tmp/node-log-query-kubelet-config.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
         # This test installs release packages or binaries that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -306,7 +320,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
     - bash -c /tmp/kubeadm-bootstrap.sh
     useExperimentalRetryJoin: true

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -227,6 +227,20 @@ spec:
       permissions: "0644"
     - content: |
         #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        if grep -q "NodeLogQuery=true" /var/lib/kubelet/kubeadm-flags.env; then
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+          echo "* adding enableSystemLogQuery: true to kubelet config"
+          printf "enableSystemLogQuery: true\n" | $${SUDO} tee --append /var/lib/kubelet/config.yaml
+          $${SUDO} systemctl restart kubelet
+        fi
+      owner: root:root
+      path: /tmp/node-log-query-kubelet-config.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
 
         set -o nounset
         set -o pipefail
@@ -295,6 +309,7 @@ spec:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
     postKubeadmCommands:
+    - bash -c /tmp/node-log-query-kubelet-config.sh
     - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/replace-k8s-binaries.sh


### PR DESCRIPTION
Add a script to the KubeadmControlPlane that adds the enableSystemLogQuery option to the kubelet config if the NodeLogQuery feature flag is set