### PR TITLE
unit tests: Update golang to 1.21.6

### DIFF
--- a/scripts/prepare_env_windows.ps1
+++ b/scripts/prepare_env_windows.ps1
@@ -1,4 +1,4 @@
-$PACKAGES= @{ git = ""; golang = "1.20.2"; make = "" }
+$PACKAGES= @{ git = ""; golang = "1.21.6"; make = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
Kubernetes has switched golang to 1.21. Because of this, the unit test runs have failures with the following message:

note: module requires Go 1.21

Updates the installed golang to 1.21.6.