### PR TITLE
Remove depreciated flag in move to external cloud-provider

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -106,7 +106,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
@@ -306,14 +305,12 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -102,7 +102,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
@@ -294,14 +293,12 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -106,7 +106,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
@@ -306,14 +305,12 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -74,7 +74,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
@@ -211,14 +210,12 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -106,7 +106,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
@@ -306,14 +305,12 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -102,7 +102,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
@@ -294,14 +293,12 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
           feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
         name: '{{ ds.meta_data["local_hostname"] }}'


### PR DESCRIPTION
In preparation for removal of in-tree cloud provider: https://github.com/kubernetes/kubernetes/pull/122857 we need to remove this flag (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4436)

/sig windows
