### PR TITLE
Disable transfer service until stabilizes in containerd

### DIFF
--- a/capz/templates/ci/patches/kubeadm-bootstrap-windows-ci.yaml
+++ b/capz/templates/ci/patches/kubeadm-bootstrap-windows-ci.yaml
@@ -20,7 +20,8 @@
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+      # use containerd local service vs transfer service until transfer service stabalizes in containerd 2.0
+      ctr.exe -n k8s.io images pull --local docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       echo "kubeadm version: "

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -89,7 +89,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+          # use containerd local service vs transfer service until transfer service stabalizes in containerd 2.0
+          ctr.exe -n k8s.io images pull --local docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
           ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           echo "kubeadm version: "

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -89,7 +89,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+          # use containerd local service vs transfer service until transfer service stabalizes in containerd 2.0
+          ctr.exe -n k8s.io images pull --local docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
           ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           echo "kubeadm version: "

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -89,7 +89,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+          # use containerd local service vs transfer service until transfer service stabalizes in containerd 2.0
+          ctr.exe -n k8s.io images pull --local docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
           ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           echo "kubeadm version: "


### PR DESCRIPTION
This will let us continue to run the containerd nightly job

There have been several bug fixes since https://github.com/containerd/containerd/pull/9432 merged but still have a few more issues like https://github.com/containerd/containerd/pull/9717.  

Disabling so we can still get nightly signal on containerd 2.0 since we only use ctr for pre-pulling images and transfer service isn't enabled in CRI yet.