### PR TITLE
Add missing SSH rule for annual channel image

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -24,12 +24,12 @@ main() {
     export CONTROL_PLANE_MACHINE_COUNT="${AZURE_CONTROL_PLANE_MACHINE_COUNT:-"1"}"
     export WINDOWS_WORKER_MACHINE_COUNT="${WINDOWS_WORKER_MACHINE_COUNT:-"2"}"
     export WINDOWS_SERVER_VERSION="${WINDOWS_SERVER_VERSION:-"windows-2019"}"
-    export WINDOWS_CONTAINERD_URL="${WINDOWS_CONTAINERD_URL:-"https://github.com/containerd/containerd/releases/download/v1.7.8/containerd-1.7.8-windows-amd64.tar.gz"}"
+    export WINDOWS_CONTAINERD_URL="${WINDOWS_CONTAINERD_URL:-"https://github.com/containerd/containerd/releases/download/v1.7.13/containerd-1.7.13-windows-amd64.tar.gz"}"
     export GMSA="${GMSA:-""}" 
     export HYPERV="${HYPERV:-""}"
     export KPNG="${WINDOWS_KPNG:-""}"
     export CALICO_VERSION="${CALICO_VERSION:-"v3.26.1"}"
-    export TEMPLATE="${TEMPLATE:-"windows-ci.yaml"}"
+    export TEMPLATE="${TEMPLATE:-"shared-image-gallery-ci.yaml"}"
 
     # other config
     export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -103,6 +103,11 @@ spec:
           kube-proxy.exe --version
         path: C:/replace-ci-binaries.ps1
         permissions: "0744"
+      - content: |
+          $ErrorActionPreference = 'Stop'
+          New-NetFirewallRule -DisplayName 'SSH-old-behavior' -Profile 'Any' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 22
+        path: C:/ssh-setup.ps1
+        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
@@ -120,6 +125,7 @@ spec:
       - powershell C:/create-temp-folder.ps1
       - powershell C:/replace-containerd.ps1
       - powershell C:/replace-ci-binaries.ps1
+      - powershell C:/ssh-setup.ps1
       users:
       - groups: Administrators
         name: capi

--- a/capz/templates/sig/kustomization.yaml
+++ b/capz/templates/sig/kustomization.yaml
@@ -19,6 +19,13 @@ patches:
     name: .*-md-win
     namespace: default
   path: ../ci/patches/kubeadm-bootstrap-windows-ci.yaml
+- target:
+    group: bootstrap.cluster.x-k8s.io
+    version: v1beta1
+    kind: KubeadmConfigTemplate
+    name: .*-md-win
+    namespace: default
+  path: patches/kubeadm-bootstrap-ssh.yaml
 generatorOptions:
   disableNameSuffixHash: true
   labels:

--- a/capz/templates/sig/patches/kubeadm-bootstrap-ssh.yaml
+++ b/capz/templates/sig/patches/kubeadm-bootstrap-ssh.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      $ErrorActionPreference = 'Stop'
+      New-NetFirewallRule -DisplayName 'SSH-old-behavior' -Profile 'Any' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 22
+    path: C:/ssh-setup.ps1
+    permissions: "0744"
+- op: add
+  path: /spec/template/spec/preKubeadmCommands/-
+  value:
+    powershell C:/ssh-setup.ps1


### PR DESCRIPTION
Annual channel does not have functional ssh because it is missing a rule to allow port forwarding.  This adds the missing rule in the format that was previously created by the installer.  There may be a fix coming to the SSH installer at somepoint, when we can then remove this.