### PR TITLE
Use windows ci as default

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -29,7 +29,7 @@ main() {
     export HYPERV="${HYPERV:-""}"
     export KPNG="${WINDOWS_KPNG:-""}"
     export CALICO_VERSION="${CALICO_VERSION:-"v3.26.1"}"
-    export TEMPLATE="${TEMPLATE:-"shared-image-gallery-ci.yaml"}"
+    export TEMPLATE="${TEMPLATE:-"windows-ci.yaml"}"
 
     # other config
     export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"


### PR DESCRIPTION
#423 checked in a change that selected the wrong template by default and is causing failures on our testing jobs: https://github.com/kubernetes/kubernetes/issues/123650

/assign @marosset 