### PR TITLE
Include proxy in Windows unit test runs

### DIFF
--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -11,7 +11,7 @@ $RepoURL = "https://github.com/$repoOrg/$repoName"
 $LocalPullBranch = "testBranch"
 $JUNIT_FILE_NAME="junit"
 $EXTRA_PACKAGES = @("./cmd/...")
-$EXCLUDED_PACKAGES = @("./pkg/proxy/...")
+$EXCLUDED_PACKAGES = @()
 
 
 function Prepare-TestPackages {


### PR DESCRIPTION
There are some breaking unit tests in ./pkg/proxy, which is why they were excluded. But now those tests are being skipped, so we're safe to run the rest.