### PR TITLE
skipping linux-speicifc proxy packages during windows unit test execution

### DIFF
--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -11,7 +11,7 @@ $RepoURL = "https://github.com/$repoOrg/$repoName"
 $LocalPullBranch = "testBranch"
 $JUNIT_FILE_NAME="junit"
 $EXTRA_PACKAGES = @("./cmd/...")
-$EXCLUDED_PACKAGES = @()
+$EXCLUDED_PACKAGES = @("./pkg/proxy/iptables/...", "./pkg/proxy/ipvs/...", "./pkg/proxy/nftables/...")
 
 
 function Prepare-TestPackages {


### PR DESCRIPTION
Fixes #427 