### PR TITLE
unittests: Updates kubeadm build flags

### DIFF
--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -79,9 +79,9 @@ function Build-Kubeadm {
     $buildFlags = @(
         "-X 'k8s.io/component-base/version.gitTreeState=clean'",
         "-X 'k8s.io/component-base/version.gitMajor=1'",
-        "-X 'k8s.io/component-base/version.gitMinor=27'",
-        "-X 'k8s.io/component-base/version.gitVersion=v1.27.0'",
-        "-X 'k8s.io/component-base/version.gitCommit=6a61da26b6761d1b86844cdec194ccaa02b41f3'"
+        "-X 'k8s.io/component-base/version.gitMinor=30'",
+        "-X 'k8s.io/component-base/version.gitVersion=v1.30.0'",
+        "-X 'k8s.io/component-base/version.gitCommit=a06568062c41b4f0f903dcb78aa6ea348bbdecfc'"
     )
 
     Push-Location "$RepoPath"


### PR DESCRIPTION
The unittest ``cmdTestCmdConfigImagesList/valid:_latest_stable_Kubernetes_version_should_not_throw_the_warning_that_a_supported_etcd_version_cannot_be_found`` currently fails because the command ``kubeadm config images list --v=1 --kubernetes-version=stable-1`` outputs the warning ``"WARNING: could not find officially supported version of etcd for Kubernetes v1.27.15, falling back to the nearest etcd version (3.5.14-0)"``, and the test explicitly checks against this specific type of warning.

This seems to happen when the build flags used when building kubeadm are older than expected. Building with new flags solves this issue.