### PR TITLE
Cncf job migration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ capz/gmsa/configuration/gmsa-spec-writer-output.txt
 helpers/hyper-v-mutating-webhook/bin/
 capz/clusterctl
 capz/tools
+**/.vscode

--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -43,6 +43,7 @@ main() {
     export CI="${CI:-""}"
 
     set_azure_envs
+
     set_ci_version
     IS_PRESUBMIT="$(capz::util::should_build_kubernetes)"
     echo "IS_PRESUBMIT=$IS_PRESUBMIT"
@@ -378,10 +379,14 @@ run_e2e_test() {
         fi
 
         ADDITIONAL_E2E_ARGS=()
-        if [[ "$CI" == "true" ]]; then
+        if [[ "$CI" == "true" && -n "${DOCKER_CONFIG_FILE:-""}" ]]; then
             # private image repository doesn't have a way to promote images: https://github.com/kubernetes/k8s.io/pull/1929
             # So we are using a custom repository for the test "Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]"
             # Must also set label preset-windows-private-registry-cred: "true" on the job
+            
+            # This will not work in community cluster as this secret is not present (hence we only do it if ENV is set)
+            # On the community cluster we will use credential providers to a private registry in azure see:
+            # https://github.com/kubernetes-sigs/windows-testing/issues/446
             export KUBE_TEST_REPO_LIST="$SCRIPT_ROOT/../images/image-repo-list-private-registry"
             ADDITIONAL_E2E_ARGS+=("--docker-config-file=${DOCKER_CONFIG_FILE}")
         fi


### PR DESCRIPTION
Building on this PR: https://github.com/kubernetes-sigs/windows-testing/pull/439/files to build ability to test job migration to Azure CNCF subscription.