### PR TITLE
Parse prow creds when token file not present

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -463,6 +463,12 @@ set_azure_envs() {
     # shellcheck disable=SC1091
     source "${CAPZ_DIR}/hack/ensure-azcli.sh"
 
+    if [[ -z "${AZURE_FEDERATED_TOKEN_FILE:-}" && -f "${CAPZ_DIR}/hack/parse-prow-creds.sh" ]]; then
+        # older versions of capz require this to authenticate properly
+        # shellcheck disable=SC1091
+        source "${CAPZ_DIR}/hack/parse-prow-creds.sh"
+    fi
+
     # Verify the required Environment Variables are present.
     : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
     : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"


### PR DESCRIPTION
In #447, I didn't take into account that this script is used across various versions of CAPZ.  This adds a check if the token file is present then we will not parse the prow cred secret 