### PR TITLE
Update regions for new sub

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -503,7 +503,7 @@ log() {
 
 # all test regions must support AvailabilityZones
 get_random_region() {
-    local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westus2" "westus3")
+    local REGIONS=("australiaeast" "canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westus2" "northcentralus")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 


### PR DESCRIPTION
The new sub is seeing issues with our windows sku in `westus3` this follows https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5003

```
the requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_DS2_v2' is currently not available in location 'WestUS3'.
```