### PR TITLE
Revert "Wiring user identities"

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -370,7 +370,7 @@ run_e2e_test() {
 
         if [[ ! "${RUN_SERIAL_TESTS:-}" == "true" ]]; then
             export GINKGO_FOCUS=${GINKGO_FOCUS:-"\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption"}
-            export GINKGO_SKIP=${GINKGO_SKIP:-"\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[Excluded:WindowsDocker\]|\[Feature:DynamicResourceAllocation\]|Networking.Granular.Checks(.*)node-pod.communication|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute(.*)http.hook.properly|\[sig-api-machinery\].Garbage.collector"}
+            export GINKGO_SKIP=${GINKGO_SKIP:-"\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[Excluded:WindowsDocker\]|\[Feature:DynamicResourceAllocation\]|Networking.Granular.Checks(.*)node-pod.communication|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute(.*)http.hook.properly|\[sig-api-machinery\].Garbage.collector|pull.from.private.registry.with.secret"}
             export GINKGO_NODES="${GINKGO_NODES:-"4"}"
         else
             export GINKGO_FOCUS=${GINKGO_FOCUS:-"(\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-autoscaling\].\[Feature:HPA\]|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector"}
@@ -379,7 +379,7 @@ run_e2e_test() {
         fi
 
         ADDITIONAL_E2E_ARGS=()
-        if [[ "$CI" == "true" ]]; then
+        if [[ "$CI" == "true" && -n "${DOCKER_CONFIG_FILE:-""}" ]]; then
             # private image repository doesn't have a way to promote images: https://github.com/kubernetes/k8s.io/pull/1929
             # So we are using a custom repository for the test "Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]"
             # Must also set label preset-windows-private-registry-cred: "true" on the job
@@ -387,7 +387,8 @@ run_e2e_test() {
             # This will not work in community cluster as this secret is not present (hence we only do it if ENV is set)
             # On the community cluster we will use credential providers to a private registry in azure see:
             # https://github.com/kubernetes-sigs/windows-testing/issues/446
-            export KUBE_TEST_REPO_LIST="$SCRIPT_ROOT/../images/image-repo-list-private-registry-community"
+            export KUBE_TEST_REPO_LIST="$SCRIPT_ROOT/../images/image-repo-list-private-registry"
+            ADDITIONAL_E2E_ARGS+=("--docker-config-file=${DOCKER_CONFIG_FILE}")
         fi
 
         # K8s 1.24 and below use ginkgo v1 which has slighly different args

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -122,8 +122,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -117,8 +117,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -127,8 +127,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -435,7 +433,6 @@ spec:
       annotations:
         runtime: containerd
     spec:
-      identity: UserAssigned
       image:
         sharedGallery:
           gallery: SigwinTestingImages
@@ -449,6 +446,4 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -88,8 +88,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
@@ -332,7 +330,6 @@ spec:
       annotations:
         runtime: containerd
     spec:
-      identity: UserAssigned
       image:
       osDisk:
         diskSizeGB: 128
@@ -340,6 +337,4 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -122,8 +122,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -429,7 +427,6 @@ spec:
       annotations:
         runtime: containerd
     spec:
-      identity: UserAssigned
       image:
         marketplace:
           offer: capi-windows
@@ -442,6 +439,4 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -117,8 +117,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -417,7 +415,6 @@ spec:
       annotations:
         runtime: containerd
     spec:
-      identity: UserAssigned
       image:
         marketplace:
           offer: capi-windows
@@ -430,6 +427,4 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/images/image-repo-list-private-registry-community
+++ b/images/image-repo-list-private-registry-community
@@ -1,1 +1,0 @@
-gcAuthenticatedRegistry: e2eprivatecommunity.azurecr.io


### PR DESCRIPTION
This reverts commit 8dc7bb1d147adc1875c8908edd6365d3ef929f37.

This is passing for ws2022 but started failing in ws2019 with `E0802 14:31:52.114636    6048 kuberuntime_manager.go:269] "Failed to register CRI auth plugins" err="plugin binary directory /var/lib/kubelet/credential-provider did not exist"`

also seeing some interesting errors in logs:

```
b1d0a36836c1","Type":"ContainerStarted","Data":"34516e609fce5ffa186d271994a9288502d1a52e440cb9ca51a309d5520b6eea"}
E0802 17:18:50.454190    4912 log.go:32] "PullImage from image service failed" err="rpc error: code = NotFound desc = failed to pull and unpack image \"e2eprivatecommunity.azurecr.io/alpine:3.7\": failed to resolve reference \"e2eprivatecommunity.azurecr.io/alpine:3.7\": e2eprivatecommunity.azurecr.io/alpine:3.7: not found" image="e2eprivatecommunity.azurecr.io/alpine:3.7"
E0802 17:18:50.755482    4912 log.go:32] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"e2eprivatecommunity.azurecr.io/alpine:3.7\": failed to resolve reference \"e2eprivatecommunity.azurecr.io/alpine:3.7\": failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://e2eprivatecommunity.azurecr.io/oauth2/token?scope=repository%3Aalpine%3Apull&service=e2eprivatecommunity.azurecr.io: 401 Unauthorized" image="e2eprivatecommunity.azurecr.io/alpine:3.7"
E0802 17:18:50.755904    4912 kuberuntime_manager.go:1272] "Unhandled Error" err="container &Container{Name:image-pull-test,Image:e2eprivatecommunity.azurecr.io/alpine:3.7,Command:[/bin/sh -c while true; do sleep 1; done],Args:[],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:kube-api-access-2fl6v,ReadOnly:true,MountPath:/var/run/secrets/kubernetes.io/serviceaccount,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:Always,SecurityContext:nil,Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,} start failed in pod image-pull-teste6f5f010-1cbc-416c-a4fd-82d2361bb2de_container-runtime-2696(fb7746e7-1a03-4678-93c5-b1d0a36836c1): ErrImagePull: [rpc error: code = NotFound desc = failed to pull and unpack image \"e2eprivatecommunity.azurecr.io/alpine:3.7\": failed to resolve reference \"e2eprivatecommunity.azurecr.io/alpine:3.7\": e2eprivatecommunity.azurecr.io/alpine:3.7: not found, failed to pull and unpack image \"e2eprivatecommunity.azurecr.io/alpine:3.7\": failed to resolve reference \"e2eprivatecommunity.azurecr.io/alpine:3.7\": failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://e2eprivatecommunity.azurecr.io/oauth2/token?scope=repository%3Aalpine%3Apull&service=e2eprivatecommunity.azurecr.io: 401 Unauthorized]" logger="UnhandledError"
```

While we investigate, to unblock the release-informing job we will revert this.

/assign @marosset @ritikaguptams 