### PR TITLE
Stop setting HPAContianerMetrics feature-gate because it will be removed in v1.32

### DIFF
--- a/capz/readme.md
+++ b/capz/readme.md
@@ -65,7 +65,7 @@ export AZURE_SSH_PUBLIC_KEY_FILE="$HOME/.ssh/id_rsa.pub"
 | `API_SERVER_FEATURE_GATES` | Comma-separated list of feature-gates and their values to pass to the kube-apiserver (Defaults to "") |
 | `AZURE_LOCATION` | The azure region to deploy resources into. If not specified a random region will be selected) |
 | `KUBERNETES_VERSION`  | Valid values are `latest` (default) and  `latest-1.xx` where x is valid kubernetes minor version such as `latest-1.24` |
-| `NODE_FEATURE_GATES` | Comma-seperated list of feature-gates and their values to pass to the kubelet (Defaults to "HPAContainerMetrics=true") |
+| `NODE_FEATURE_GATES` | Comma-seperated list of feature-gates and their values to pass to the kubelet (Defaults to "") |
 | `NODE_MACHINE_TYPE` | The [Azure vm size](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes) to use for the nodes  |
 | `RUN_SERIAL_TESTS` | If set to `true` then serial slow tests will be run with default ginkgo settings |
 | `SKIP_CREATE` | Don't create a cluster.  Must set `CLUSTER_NAME` and have current a workload cluster kubeconfig file with name `./"${CLUSTER_NAME}".kubeconfig` |

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -121,7 +121,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -198,14 +198,13 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:
@@ -321,13 +320,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -116,7 +116,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -195,14 +195,13 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:
@@ -308,13 +307,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -126,7 +126,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -204,14 +204,13 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:
@@ -327,13 +326,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -88,7 +88,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -164,14 +164,13 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:
@@ -225,13 +224,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -121,7 +121,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -198,14 +198,13 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:
@@ -321,13 +320,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -116,7 +116,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -195,14 +195,13 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-          feature-gates: ${API_SERVER_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:
@@ -308,13 +307,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: ${NODE_FEATURE_GATES:-"HPAContainerMetrics=true"}
+          feature-gates: ${NODE_FEATURE_GATES:-""}
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk


### PR DESCRIPTION
This feature-gate was set to on-by-default in v1.27 (https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/features/kube_features.go#L1008) so we don't need to update anything else to have the feature turned on for all our test passes

/assign @jsturtevant 
/cc @ritikaguptams 