### PR TITLE
Move to compute gallery

### DIFF
--- a/capz/templates/ci/kustomization.yaml
+++ b/capz/templates/ci/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: default
 resources:
   - ../windows-base.yaml
 patches:
-- path: patches/market-place.yaml
+- path: patches/compute-gallery.yaml
 - target:
     group: controlplane.cluster.x-k8s.io
     version: v1beta1

--- a/capz/templates/ci/patches/compute-gallery.yaml
+++ b/capz/templates/ci/patches/compute-gallery.yaml
@@ -9,8 +9,7 @@ spec:
   template:
     spec:
       image:
-        marketplace:
-          offer: capi-windows
-          publisher: cncf-upstream
-          sku: ${IMAGE_SKU:=windows-2019-containerd-gen1}
-          version: ${IMAGE_VERSION:="latest"}
+        computeGallery:
+          name: "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
+          gallery: "${IMAGE_GALLERY:=capi-win-2022-containerd}"
+          version: "${IMAGE_VERSION:=latest}"

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -403,11 +403,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
+        computeGallery:
+          gallery: capi-ubun2-2404
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -431,11 +430,10 @@ spec:
     spec:
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi-windows
-          publisher: cncf-upstream
-          sku: ${IMAGE_SKU:=windows-2019-containerd-gen1}
-          version: ${IMAGE_VERSION:="latest"}
+        computeGallery:
+          gallery: ${IMAGE_GALLERY:=capi-win-2022-containerd}
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -391,11 +391,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
+        computeGallery:
+          gallery: capi-ubun2-2404
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -419,11 +418,10 @@ spec:
     spec:
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi-windows
-          publisher: cncf-upstream
-          sku: ${IMAGE_SKU:=windows-2019-containerd-gen1}
-          version: ${IMAGE_VERSION:="latest"}
+        computeGallery:
+          gallery: ${IMAGE_GALLERY:=capi-win-2022-containerd}
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/capz/templates/pr/kustomization.yaml
+++ b/capz/templates/pr/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: default
 resources:
   - ../windows-base.yaml
 patches:
-- path: ../ci/patches/market-place.yaml
+- path: ../ci/patches/compute-gallery.yaml
 - path: ./patches/kubeadm-control-plane-pr.yaml
 - target:
     group: controlplane.cluster.x-k8s.io

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -406,11 +406,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
+        computeGallery:
+          gallery: capi-ubun2-2404
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -303,11 +303,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
+        computeGallery:
+          name: "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
+          gallery: "capi-ubun2-2404"
+          version: "${IMAGE_VERSION:=latest}"
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -400,11 +400,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
+        computeGallery:
+          gallery: capi-ubun2-2404
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -427,11 +426,10 @@ spec:
         runtime: containerd
     spec:
       image:
-        marketplace:
-          offer: capi-windows
-          publisher: cncf-upstream
-          sku: ${IMAGE_SKU:=windows-2019-containerd-gen1}
-          version: ${IMAGE_VERSION:="latest"}
+        computeGallery:
+          gallery: ${IMAGE_GALLERY:=capi-win-2022-containerd}
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         managedDisk:

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -388,11 +388,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
+        computeGallery:
+          gallery: capi-ubun2-2404
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -415,11 +414,10 @@ spec:
         runtime: containerd
     spec:
       image:
-        marketplace:
-          offer: capi-windows
-          publisher: cncf-upstream
-          sku: ${IMAGE_SKU:=windows-2019-containerd-gen1}
-          version: ${IMAGE_VERSION:="latest"}
+        computeGallery:
+          gallery: ${IMAGE_GALLERY:=capi-win-2022-containerd}
+          name: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          version: ${IMAGE_VERSION:=latest}
       osDisk:
         diskSizeGB: 128
         managedDisk:


### PR DESCRIPTION
CAPZ is now publishing images to community gallery that lives in the CNCF subscription.  See https://capz.sigs.k8s.io/self-managed/custom-images.html?highlight=computeGallery#using-azure-community-gallery and https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5167.

This also allows us to start to use the Windows server 2025 image.

