### PR TITLE
copy ssh key to administrator authorized keys

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -84,6 +84,11 @@ spec:
         path: C:/collect-hns-crashes.ps1
         permissions: "0744"
       - content: |
+          ${AZURE_SSH_PUBLIC_KEY:=""}
+        owner: root:root
+        path: C:/ProgramData/ssh/administrators_authorized_keys
+        permissions: "0640"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -84,6 +84,11 @@ spec:
         path: C:/collect-hns-crashes.ps1
         permissions: "0744"
       - content: |
+          ${AZURE_SSH_PUBLIC_KEY:=""}
+        owner: root:root
+        path: C:/ProgramData/ssh/administrators_authorized_keys
+        permissions: "0640"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -84,6 +84,11 @@ spec:
         path: C:/collect-hns-crashes.ps1
         permissions: "0744"
       - content: |
+          ${AZURE_SSH_PUBLIC_KEY:=""}
+        owner: root:root
+        path: C:/ProgramData/ssh/administrators_authorized_keys
+        permissions: "0640"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -83,6 +83,11 @@ spec:
           sc.exe start sshd
         path: C:/collect-hns-crashes.ps1
         permissions: "0744"
+      - content: |
+          ${AZURE_SSH_PUBLIC_KEY:=""}
+        owner: root:root
+        path: C:/ProgramData/ssh/administrators_authorized_keys
+        permissions: "0640"
       joinConfiguration:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -84,6 +84,11 @@ spec:
         path: C:/collect-hns-crashes.ps1
         permissions: "0744"
       - content: |
+          ${AZURE_SSH_PUBLIC_KEY:=""}
+        owner: root:root
+        path: C:/ProgramData/ssh/administrators_authorized_keys
+        permissions: "0640"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -84,6 +84,11 @@ spec:
         path: C:/collect-hns-crashes.ps1
         permissions: "0744"
       - content: |
+          ${AZURE_SSH_PUBLIC_KEY:=""}
+        owner: root:root
+        path: C:/ProgramData/ssh/administrators_authorized_keys
+        permissions: "0640"
+      - content: |
           $ErrorActionPreference = 'Stop'
 
           Stop-Service kubelet -Force


### PR DESCRIPTION
Admin Users require to have the public key added to c:/ProgramData/ssh/administrators_authorized_keys. [reference](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement#administrative-user)