### PR TITLE
bump golang version to v1.23.6 for unit tests

### DIFF
--- a/scripts/prepare_env_windows.ps1
+++ b/scripts/prepare_env_windows.ps1
@@ -1,4 +1,4 @@
-$PACKAGES= @{ git = ""; golang = "1.21.6"; make = "" }
+$PACKAGES= @{ git = ""; golang = "1.23.6"; make = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
quick fix to get golang version matching what is used in k/k.

I'm going to look into parallelizing the execution of unit tests and will make this configurable as part of a later PR.