### PR TITLE
Unit tests fixes and parallel

### DIFF
--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -161,6 +161,7 @@ run_remote_cmd() {
     local CMD=$3
 
     ssh -i ${SSH_KEY_FILE} ${SSH_OPTS} azureuser@${SSH_HOST} "${CMD}"
+    return $?
 
 }
 

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -206,7 +206,9 @@ echo "Install container features in VM"
 run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "powershell.exe -command { Install-WindowsFeature -Name 'Containers' -Restart }"
 wait_for_vm_restart
 
-if [ "${JOB_TYPE}" == "presubmit" ]
+# if repo name is windows-testing, the intention is to test updates to the scripts
+# as if they were running as a periodic job against kubernetes/kubernete.
+if [ "${JOB_TYPE}" == "presubmit" ] && [ "${REPO_NAME}" != "windows-testing" ]
 then
     echo "Running a presubmit job"
     # Include the -testPackages argument only if we have $TEST_PACKAGES to test.

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -161,8 +161,7 @@ run_remote_cmd() {
     local CMD=$3
 
     ssh -i ${SSH_KEY_FILE} ${SSH_OPTS} azureuser@${SSH_HOST} "${CMD}"
-    return $?
-
+    
 }
 
 enable_ssh_windows() {
@@ -207,6 +206,7 @@ echo "Install container features in VM"
 run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "powershell.exe -command { Install-WindowsFeature -Name 'Containers' -Restart }"
 wait_for_vm_restart
 
+set +e  # Temporarily disable errexit
 # if repo name is windows-testing, the intention is to test updates to the scripts
 # as if they were running as a periodic job against kubernetes/kubernete.
 if [ "${JOB_TYPE}" == "presubmit" ] && [ "${REPO_NAME}" != "windows-testing" ]
@@ -218,13 +218,14 @@ then
         test_packages_arg="-testPackages ${TEST_PACKAGES}"
     fi
 
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_unit_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}" || true
+    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_unit_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
     exit_code=$?
 else
     echo "Running periodic job"
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} 'c:/k8s_unit_windows.ps1' || true
+    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} 'c:/k8s_unit_windows.ps1'
     exit_code=$?
 fi
+set -e  # Re-enable errexit
 
 copy_from 'c:/Logs/*.xml' ${ARTIFACTS} ${VM_PUB_IP}
 destroy_resource_group

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -217,10 +217,15 @@ then
         test_packages_arg="-testPackages ${TEST_PACKAGES}"
     fi
 
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_unit_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
+    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_unit_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}" || true
+    exit_code=$?
 else
     echo "Running periodic job"
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} 'c:/k8s_unit_windows.ps1'
+    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} 'c:/k8s_unit_windows.ps1' || true
+    exit_code=$?
 fi
+
 copy_from 'c:/Logs/*.xml' ${ARTIFACTS} ${VM_PUB_IP}
 destroy_resource_group
+
+exit $exit_code

--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -120,10 +120,14 @@ function Run-K8sUnitTests {
         } -ArgumentList $package, $junit_output_file, $RepoPath
     }
 
+    $failedJobCount = 0 
     while ($jobs.Count -gt 0) {
         $finishedJob = Wait-Job -Job $jobs -Any
-    
         $result = Receive-Job -Job $finishedJob
+        
+        if ($result.ExitCode -ne 0) {
+            $failedJobCount++
+        }
     
         Write-Output "Output for package: $($result.Package)"
         Write-Output $result.Output
@@ -135,10 +139,7 @@ function Run-K8sUnitTests {
         Write-Output ("-" * 40)
     }
 
-    $results = $jobs | ForEach-Object { Receive-Job $_ }
-
-    $failedJobs = $results | Where-Object { $_.ExitCode -ne 0 }
-    if ($failedJobs) {
+    if ($failedJobCount) {
         exit 1
     } else {
         exit 0

--- a/scripts/prepare_env_windows.ps1
+++ b/scripts/prepare_env_windows.ps1
@@ -27,7 +27,12 @@ foreach ($package in $PACKAGES.Keys) {
 
 Write-Host "Set up environment."
 
-$userGoBin = "${env:HOME}\go\bin"
+if (${Env:HOME} -ne $null) {
+    $userGoBin = "${Env:HOME}\go\bin"
+} else {
+    $userGoBin = "${Env:HOMEPATH}\go\bin"
+}
+
 $path = ";c:\Program Files\Git\bin;c:\Program Files\Go\bin;${userGoBin};"
 $env:PATH+=$path
 


### PR DESCRIPTION
Fixes #472 

This PR
- fixes and issue where some powershell environments may not have $HOME set (use $HOMEPATH as a fallback)
- Runs the unit tests for various go packages in parallel
- Fixes and issue where failing unit tests do not cause the PROW job to fail

/assign @jsturtevant 