### PR TITLE
Enable the cluster worker node ManageIdentity

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -127,6 +127,8 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -417,7 +419,7 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      - providerID: ${USER_IDENTITY}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -122,6 +122,8 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -405,7 +407,7 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      - providerID: ${USER_IDENTITY}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -453,5 +453,5 @@ spec:
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID:${USER_IDENTITY}
+      - providerID: ${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -132,6 +132,8 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -420,7 +422,7 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      - providerID: ${USER_IDENTITY}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -436,6 +438,7 @@ spec:
       annotations:
         runtime: containerd
     spec:
+      identity: UserAssigned
       image:
         sharedGallery:
           gallery: SigwinTestingImages
@@ -449,4 +452,6 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID:${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -344,5 +344,5 @@ spec:
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID:${USER_IDENTITY}
+      - providerID: ${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -93,6 +93,8 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             feature-gates: ${NODE_FEATURE_GATES:-""}
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
@@ -317,7 +319,7 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      - providerID:  ${USER_IDENTITY}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -333,6 +335,7 @@ spec:
       annotations:
         runtime: containerd
     spec:
+      identity: UserAssigned
       image:
       osDisk:
         diskSizeGB: 128
@@ -340,4 +343,6 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID:${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -445,5 +445,5 @@ spec:
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID:${USER_IDENTITY}
+      - providerID: ${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -127,6 +127,8 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -414,7 +416,7 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      - providerID: ${USER_IDENTITY}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -430,6 +432,7 @@ spec:
       annotations:
         runtime: containerd
     spec:
+      identity: UserAssigned
       image:
         computeGallery:
           gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
@@ -441,4 +444,6 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID:${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -122,6 +122,8 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -402,7 +404,7 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      - providerID: ${USER_IDENTITY}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -418,6 +420,7 @@ spec:
       annotations:
         runtime: containerd
     spec:
+      identity: UserAssigned
       image:
         computeGallery:
           gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
@@ -429,4 +432,6 @@ spec:
           storageAccountType: Premium_LRS
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID:${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -433,5 +433,5 @@ spec:
         osType: Windows
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID:${USER_IDENTITY}
+      - providerID: ${USER_IDENTITY}
       vmSize: ${AZURE_NODE_MACHINE_TYPE:-"Standard_D4s_v3"}

--- a/images/image-repo-list-private-registry-community
+++ b/images/image-repo-list-private-registry-community
@@ -1,0 +1,1 @@
+gcAuthenticatedRegistry: e2eprivatecommunity.azurecr.io


### PR DESCRIPTION
This is on top of PR https://github.com/kubernetes-sigs/windows-testing/pull/460 and trying to address: https://github.com/kubernetes-sigs/windows-testing/pull/465. it looks to me that the test failure is more like the pre-created MI does not match the cluster region, instead of windows SKU related. I have tested with my private registry with this change, and it works fine for both 2019 and 2022