### PR TITLE
fix: remove deprecated kube-apiserver cloud-provider arg

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -202,7 +202,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -199,7 +199,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -208,7 +208,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -168,7 +168,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -202,7 +202,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -199,7 +199,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${API_SERVER_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:


### PR DESCRIPTION

This PR:

- removes the deprecated kube-apiserver cloud-provider arg which was deprecated in [release 1.29](https://github.com/kubernetes/kubernetes/blob/f0077a3689669018557de723a0416fda267d132f/CHANGELOG/CHANGELOG-1.29.md#:~:text=%40sttts\)-,Deprecated%20the%20%2D%2Dcloud%2Dprovider%20and%20%2D%2Dcloud%2Dconfig%20CLI%20parameters%20in%20kube%2Dapiserver.%20These%20parameters%20will%20be%20removed%20in%20a%20future%20release.%20\(%23120903%2C%20%40dims\)%20%5BSIG%20API%20Machinery%5D,-Dynamic%20resource%20allocation)
- it has been removed in release 1.33 through this [PR](https://github.com/kubernetes/kubernetes/pull/130162)