### PR TITLE
Add prow job scripts for windows node e2e test

### DIFF
--- a/scripts/ci-k8s-common.sh
+++ b/scripts/ci-k8s-common.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o errtrace
-
-
 function onError(){
     az group list | jq ' .[] | .name' | grep ${AZURE_RESOURCE_GROUP}
-    if [ $? -ne 0 ]; then
+    if [ $? -eq 0 ]; then
         az group delete -n ${AZURE_RESOURCE_GROUP} --yes --no-wait
     fi
 }
 
-trap onError ERR 
+
 
 ensure_azure_cli() {
     if [[ -z "$(command -v az)" ]]; then

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+PROW_BUILD_ID="${BUILD_ID:-000000000000}"
+AZURE_RESOURCE_GROUP="win-e2e-node-${PROW_BUILD_ID}"
+AZURE_DEFAULT_IMG="MicrosoftWindowsServer:WindowsServer:2022-datacenter-core-smalldisk-g2:latest"
+SSH_OPTS="-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+AZURE_IMG="${WIN_VM_IMG:-$AZURE_DEFAULT_IMG}"
+VM_NAME="winTestVM"
+VM_LOCATION="${VM_LOCATION:-westus2}"
+VM_SIZE="${VM_SIZE:-Standard_D2s_v3}"
+ARTIFACTS="${ARTIFACTS:-/var/log/artifacts}"
+CONTAINERD_VERSION="${CONTAINERD_VERSION:-1.7.16}"
+GINKGO_FOCUS="${GINKGO_FOCUS:\[sig-windows\]|\[Feature:Windows\]}"
+
+SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
+SCRIPT_ROOT=$(dirname "${SCRIPT_PATH}")
+source ${SCRIPT_ROOT}/ci-k8s-common.sh
+
+ensure_azure_cli
+build_resource_group
+build_test_vm
+generate_ssh_key
+enable_ssh_windows
+test_ssh_connection
+echo "Test VM created. SSH connection working"
+
+echo "Install container features in VM"
+run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "powershell.exe -command { Install-WindowsFeature -Name 'Containers' -Restart }"
+wait_for_vm_restart
+
+copy_to ./scripts/prepare_env_windows.ps1 '/prepare_env_windows.ps1' ${VM_PUB_IP}
+copy_to ./scripts/prepare_e2e_node_windows.ps1 '/prepare_e2e_node_windows.ps1' ${VM_PUB_IP}
+copy_to ./scripts/k8s_e2e_node_windows.ps1 '/k8s_e2e_node_windows.ps1' ${VM_PUB_IP}
+
+run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/prepare_env_windows.ps1"
+run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/prepare_e2e_node_windows.ps1 -ContainerdVersion ${CONTAINERD_VERSION}"
+
+if [ "${JOB_TYPE}" == "presubmit" ]; then
+    if [ "${REPO_NAME}" == "kubernetes" ]; then
+        echo "Running a presubmit job against kubernetes/kubernetes"
+        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} \
+            -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg} -ginkgoFocus ${GINKGO_FOCUS}"
+    else
+        echo "Dry-Running a presubmit job against ${REPO_NAME}"
+        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -ginkgoFocus ${GINKGO_FOCUS}" -dryRun true
+    fi
+    exit_code=$?
+else
+    echo "Running periodic job"
+    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -ginkgoFocus ${GINKGO_FOCUS}"
+    exit_code=$?
+fi
+copy_from 'c:/Logs/*.xml' ${ARTIFACTS} ${VM_PUB_IP}
+destroy_resource_group
+exit $exit_code

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -15,7 +15,7 @@ VM_LOCATION="${VM_LOCATION:-westus2}"
 VM_SIZE="${VM_SIZE:-Standard_D2s_v3}"
 ARTIFACTS="${ARTIFACTS:-/var/log/artifacts}"
 CONTAINERD_VERSION="${CONTAINERD_VERSION:-1.7.16}"
-GINKGO_FOCUS="${GINKGO_FOCUS:\[sig-windows\]|\[Feature:Windows\]}"
+GINKGO_FOCUS="${GINKGO_FOCUS:-\[sig-windows\]|\[Feature:Windows\]}"
 
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPT_ROOT=$(dirname "${SCRIPT_PATH}")

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -47,7 +47,7 @@ if [ "${JOB_TYPE}" == "presubmit" ]; then
             -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
     else
         echo "Dry-Running a presubmit job against ${REPO_NAME}"
-        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1" -dryRun true
+        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -dryRun true"
     fi
     exit_code=$?
 else

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -15,7 +15,7 @@ VM_LOCATION="${VM_LOCATION:-westus2}"
 VM_SIZE="${VM_SIZE:-Standard_D2s_v3}"
 ARTIFACTS="${ARTIFACTS:-/var/log/artifacts}"
 CONTAINERD_VERSION="${CONTAINERD_VERSION:-1.7.16}"
-GINKGO_FOCUS="${GINKGO_FOCUS:-\[sig-windows\]|\[Feature:Windows\]}"
+export GINKGO_FOCUS="${GINKGO_FOCUS:-\[sig-windows\]|\[Feature:Windows\]}"
 
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPT_ROOT=$(dirname "${SCRIPT_PATH}")
@@ -44,15 +44,15 @@ if [ "${JOB_TYPE}" == "presubmit" ]; then
     if [ "${REPO_NAME}" == "kubernetes" ]; then
         echo "Running a presubmit job against kubernetes/kubernetes"
         run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} \
-            -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg} -ginkgoFocus ${GINKGO_FOCUS}"
+            -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
     else
         echo "Dry-Running a presubmit job against ${REPO_NAME}"
-        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -ginkgoFocus ${GINKGO_FOCUS}" -dryRun true
+        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1" -dryRun true
     fi
     exit_code=$?
 else
     echo "Running periodic job"
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -ginkgoFocus ${GINKGO_FOCUS}"
+    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1"
     exit_code=$?
 fi
 copy_from 'c:/Logs/*.xml' ${ARTIFACTS} ${VM_PUB_IP}

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -12,7 +12,7 @@ SSH_OPTS="-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHost
 AZURE_IMG="${WIN_VM_IMG:-$AZURE_DEFAULT_IMG}"
 VM_NAME="winTestVM"
 VM_LOCATION="${VM_LOCATION:-westus2}"
-VM_SIZE="${VM_SIZE:-Standard_D2s_v3}"
+VM_SIZE="${VM_SIZE:-Standard_D8s_v5}"
 ARTIFACTS="${ARTIFACTS:-/var/log/artifacts}"
 CONTAINERD_VERSION="${CONTAINERD_VERSION:-1.7.16}"
 export GINKGO_FOCUS="${GINKGO_FOCUS:-\[sig-windows\]|\[Feature:Windows\]}"

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -44,10 +44,10 @@ if [ "${JOB_TYPE}" == "presubmit" ]; then
     if [ "${REPO_NAME}" == "kubernetes" ]; then
         echo "Running a presubmit job against kubernetes/kubernetes"
         run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} \
-            -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
+            -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF}"
     else
         echo "Dry-Running a presubmit job against ${REPO_NAME}"
-        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -dryRun true"
+        run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_e2e_node_windows.ps1 -dryRun 'true'"
     fi
     exit_code=$?
 else

--- a/scripts/ci-k8s-e2e-node-test.sh
+++ b/scripts/ci-k8s-e2e-node-test.sh
@@ -39,6 +39,11 @@ copy_to ./scripts/prepare_env_windows.ps1 '/prepare_env_windows.ps1' ${VM_PUB_IP
 copy_to ./scripts/prepare_e2e_node_windows.ps1 '/prepare_e2e_node_windows.ps1' ${VM_PUB_IP}
 copy_to ./scripts/k8s_e2e_node_windows.ps1 '/k8s_e2e_node_windows.ps1' ${VM_PUB_IP}
 
+# Get the Go version from the kubekins image that runs this script and pass that to prepare_env_windows.ps1
+GO_VERSION_RAW=$(go version | awk '{print $3}')
+GO_VERSION=${GO_VERSION_RAW#go}
+echo "Using Go version: ${GO_VERSION}"
+run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/prepare_env_windows.ps1 -goVersion ${GO_VERSION}"
 run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/prepare_env_windows.ps1"
 run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/prepare_e2e_node_windows.ps1 -ContainerdVersion ${CONTAINERD_VERSION}"
 

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -24,6 +24,8 @@ SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPT_ROOT=$(dirname "${SCRIPT_PATH}")
 source ${SCRIPT_ROOT}/ci-k8s-common.sh
 
+trap onError ERR 
+
 ensure_azure_cli
 build_resource_group
 build_test_vm
@@ -47,6 +49,7 @@ if [ "${SKIP_FAILING_TESTS,,}" = "false" ]; then
 fi
 
 set +e  # Temporarily disable errexit
+trap - ERR   # Temporarily disable the ERR trap
 # if repo name is windows-testing, the intention is to test updates to the scripts
 # as if they were running as a periodic job against kubernetes/kubernete.
 if [ "${JOB_TYPE}" == "presubmit" ] && [ "${REPO_NAME}" != "windows-testing" ]
@@ -66,6 +69,7 @@ else
     exit_code=$?
 fi
 set -e  # Re-enable errexit
+trap onError ERR  # Re-enable the ERR trap
 
 copy_from 'c:/Logs/*.xml' ${ARTIFACTS} ${VM_PUB_IP}
 destroy_resource_group

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+!/bin/bash
 
 set -o errexit
 set -o nounset

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 set -o errexit
 set -o nounset

--- a/scripts/k8s_e2e_node_windows.ps1
+++ b/scripts/k8s_e2e_node_windows.ps1
@@ -11,6 +11,8 @@ $RepoPath = "c:/$repoName"
 $RepoURL = "https://github.com/$repoOrg/$repoName"
 $LocalPullBranch = "testBranch"
 
+$ErrorActionPreference = "Stop"
+
 function Prepare-LogsDir {
     if (Test-Path $LogsDirPath) {
         Write-Host "Logs directory already exists. Deleting it."

--- a/scripts/k8s_e2e_node_windows.ps1
+++ b/scripts/k8s_e2e_node_windows.ps1
@@ -3,7 +3,6 @@ param (
     [string]$repoOrg = "kubernetes",
     [string]$pullRequestNo,
     [string]$pullBaseRef = "master",
-    [string]$ginkgoFocus,
     [string]$dryRun = "false"
 )
 
@@ -66,7 +65,7 @@ function Run-K8se2enodeWindowsTests {
         --test.paniconexit0 `
         --container-runtime-endpoint "npipe://./pipe/containerd-containerd" `
         --prepull-images=false `
-        --ginkgo.focus "$GINKGO_FOCUS" `
+        --ginkgo.focus "$env:GINKGO_FOCUS" `
         --k8s-bin-dir $env:KUBELET_PATH `
         --report-dir $LogsDirPath `
         --report-complete-junit

--- a/scripts/k8s_e2e_node_windows.ps1
+++ b/scripts/k8s_e2e_node_windows.ps1
@@ -55,6 +55,8 @@ function Run-K8se2enodeWindowsTests {
     
     if ($dryRun -eq "true") {
         Write-Host "Running tests in dry run mode. Skipping test execution."
+        # Create a dummy file to indicate dry ru
+        New-Item -ItemType File -Path (Join-Path -Path $LogsDirPath -ChildPath "dryrun.xml") -Force
         return
     }
 

--- a/scripts/k8s_e2e_node_windows.ps1
+++ b/scripts/k8s_e2e_node_windows.ps1
@@ -1,0 +1,80 @@
+param (
+    [string]$repoName = "kubernetes",
+    [string]$repoOrg = "kubernetes",
+    [string]$pullRequestNo,
+    [string]$pullBaseRef = "master",
+    [string]$ginkgoFocus,
+    [string]$dryRun = "false"
+)
+
+$LogsDirPath = "c:/Logs"
+$RepoPath = "c:/$repoName"
+$RepoURL = "https://github.com/$repoOrg/$repoName"
+$LocalPullBranch = "testBranch"
+
+function Prepare-LogsDir {
+    if (Test-Path $LogsDirPath) {
+        Write-Host "Logs directory already exists. Deleting it."
+        Remove-Item -Recurse -Force $LogsDirPath
+    }
+    mkdir $LogsDirPath
+}
+
+function Clone-TestRepo {
+    Write-Host "Cloning $repoName repo"
+    git clone --branch $pullBaseRef $RepoURL $RepoPath --depth=1
+    if (($pullRequestNo -ne $null) -and ($pullRequestNo -ne "")) {
+        Write-Host "Pulling PR $pullRequestNo changes"
+        cd $RepoPath
+        git fetch origin refs/pull/$pullRequestNo/head:$LocalPullBranch
+        git checkout $LocalPullBranch
+        if (! $?) {
+            Write-Host "Failed to pull PR $pullRequestNo changes. Exiting"
+            exit
+        }
+    }
+}
+
+function Build-Kubelet {
+    Write-Host "Building kubelet"
+
+    Push-Location "$RepoPath"
+    go build -o .\_output\kubelet.exe .\cmd\kubelet\
+
+    Write-Host "Building kube-log-runner"
+    go build -o .\_output\kube-log-runner.exe .\staging\src\k8s.io\component-base\logs\kube-log-runner
+    
+    $outputDir = Join-Path -Path $RepoPath -ChildPath "_output"
+    $env:KUBELET_PATH = $outputDir
+    Pop-Location
+}
+
+function Run-K8se2enodeWindowsTests {
+    Push-Location "$RepoPath"
+    
+    $GINKGO_FOCUS = $ginkgoFocus
+    
+    if ($dryRun -eq "true") {
+        Write-Host "Running tests in dry run mode. Skipping test execution."
+        return
+    }
+
+    Write-Host "Running e2e node tests"
+    go test ./test/e2e_node `
+        --bearer-token=vQIYfdCt7wIFOZtO `
+        --test.v `
+        --test.paniconexit0 `
+        --container-runtime-endpoint "npipe://./pipe/containerd-containerd" `
+        --prepull-images=false `
+        --ginkgo.focus "$GINKGO_FOCUS" `
+        --k8s-bin-dir $env:KUBELET_PATH `
+        --report-dir $LogsDirPath `
+        --report-complete-junit
+        
+    Pop-Location
+}
+
+Prepare-LogsDir
+Clone-TestRepo
+Build-Kubelet
+Run-K8se2enodeWindowsTests

--- a/scripts/prepare_e2e_node_windows.ps1
+++ b/scripts/prepare_e2e_node_windows.ps1
@@ -1,0 +1,83 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$ContainerdVersion
+)
+
+$ErrorActionPreference = "Stop"
+
+# Install containerd, based on: https://github.com/containerd/containerd/blob/main/docs/getting-started.md#installing-containerd-on-windows
+# If containerd previously installed run:
+Stop-Service containerd -ErrorAction Continue
+sc.exe delete containerd -ErrorAction Continue
+
+# Download and extract desired containerd Windows binaries
+curl.exe -LO https://github.com/containerd/containerd/releases/download/v$ContainerdVersion/containerd-$ContainerdVersion-windows-amd64.tar.gz
+tar.exe xvf .\containerd-$ContainerdVersion-windows-amd64.tar.gz
+
+# Copy
+Copy-Item -Path .\bin -Destination $Env:ProgramFiles\containerd -Recurse -Force
+
+# add the binaries (containerd.exe, ctr.exe) in $env:Path
+$Path = [Environment]::GetEnvironmentVariable("PATH", "Machine") + [IO.Path]::PathSeparator + "$Env:ProgramFiles\containerd"
+[Environment]::SetEnvironmentVariable( "Path", $Path, "Machine")
+# reload path, so you don't have to open a new PS terminal later if needed
+$Env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+# configure
+containerd.exe config default | Out-File $Env:ProgramFiles\containerd\config.toml -Encoding ascii
+# Review the configuration. Depending on setup you may want to adjust:
+# - the sandbox_image (Kubernetes pause image)
+# - cni bin_dir and conf_dir locations
+Get-Content $Env:ProgramFiles\containerd\config.toml
+
+Add-MpPreference -ExclusionProcess "$Env:ProgramFiles\containerd\containerd.exe"
+
+# Register and start service
+#containerd.exe --register-service
+# Start-Service containerd
+# Use nssm to register and start containerd as a service, which can get a better logging
+curl.exe -LO https://upstreamartifacts.azureedge.net/nssm/nssm.exe
+Add-MpPreference -ExclusionProcess ".\nssm.exe"
+./nssm.exe install containerd "$Env:ProgramFiles\containerd.\containerd.exe"
+./nssm.exe set containerd AppStdout "$Env:ProgramFiles\containerd\containerd.log"
+./nssm.exe set containerd AppStderr "$Env:ProgramFiles\containerd\containerd.err.log"
+./nssm.exe start containerd
+
+# Setting up network https://www.jamessturtevant.com/posts/Windows-Containers-on-Windows-10-without-Docker-using-Containerd/
+# Create the folder for cni binaries and configuration
+mkdir -force "$Env:ProgramFiles\containerd\cni\bin"
+mkdir -force "$Env:ProgramFiles\containerd\cni\conf"
+
+# Download and extract the CNI plugins
+curl.exe -LO https://github.com/microsoft/windows-container-networking/releases/download/v0.3.1/windows-container-networking-cni-amd64-v0.3.1.zip
+Expand-Archive windows-container-networking-cni-amd64-v0.3.1.zip -DestinationPath "$Env:ProgramFiles\containerd\cni\bin" -Force
+
+# Create a nat network
+curl.exe -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
+Import-Module ./hns.psm1
+
+$subnet="10.0.0.0/16" 
+$gateway="10.0.0.1"
+New-HNSNetwork -Type Nat -AddressPrefix $subnet -Gateway $gateway -Name "nat"
+
+#Set up the containerd network config using the same gateway and subnet.
+@"
+{
+    "cniVersion": "0.2.0",
+    "name": "nat",
+    "type": "nat",
+    "master": "Ethernet",
+    "ipam": {
+        "subnet": "$subnet",
+        "routes": [
+            {
+                "gateway": "$gateway"
+            }
+        ]
+    },
+    "capabilities": {
+        "portMappings": true,
+        "dns": true
+    }
+}
+"@ | Set-Content "$Env:ProgramFiles\containerd\cni\conf\0-containerd-nat.conf" -Force


### PR DESCRIPTION
Objective:
To make scripts ready for adding prow job of windows e2e node test.

Refactor the bash file, so that most of the common part can be used by both unit test and windows e2e node test.
Local run (from a linux machine) passed for both unit test and e2e node test

The running of this prow job will have dependency on adding the windows e2e node test in k8s repo