### PR TITLE
Bump Calico version to 3.29

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -28,7 +28,7 @@ main() {
     export GMSA="${GMSA:-""}" 
     export HYPERV="${HYPERV:-""}"
     export KPNG="${WINDOWS_KPNG:-""}"
-    export CALICO_VERSION="${CALICO_VERSION:-"v3.26.1"}"
+    export CALICO_VERSION="${CALICO_VERSION:-"v3.29.2"}"
     export TEMPLATE="${TEMPLATE:-"windows-ci.yaml"}"
     export CAPI_VERSION="${CAPI_VERSION:-"v1.7.2"}"
     export HELM_VERSION=v3.15.2

--- a/capz/templates/calico/values.yaml
+++ b/capz/templates/calico/values.yaml
@@ -1,0 +1,18 @@
+installation:
+  cni:
+    type: Calico
+  calicoNetwork:
+    bgp: Disabled
+    mtu: 1350
+    windowsDataplane: HNS
+    ipPools:
+    - cidr: 192.168.0.0/16
+      encapsulation: VXLAN
+  serviceCIDRs: 
+    - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+# Image and registry configuration for the tigera/operator pod.
+tigeraOperator:
+  image: tigera/operator
+  registry: mcr.microsoft.com/oss
+calicoctl:
+  image: mcr.microsoft.com/oss/calico/ctl


### PR DESCRIPTION
Calico isn't actively tested for 3.26.x. Bumping it to 3.28 gives reasonable coverage of currently supported Kubernetes versions.
From CAPZ Slack, it does not look like there is any limitation on the version that can be used with CAPZ - https://kubernetes.slack.com/archives/CEX9HENG7/p1697054837360589?thread_ts=1697048137.410809&channel=CEX9HENG7&message_ts=1697054837.360589

Therefore, I propose we bump CALICO_VERSION to 3.28.x, as it's an actively maintained version.