### PR TITLE
unittests: Updates kubeadm build flags

### DIFF
--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -119,9 +119,9 @@ function Build-Kubeadm {
     $buildFlags = @(
         "-X 'k8s.io/component-base/version.gitTreeState=clean'",
         "-X 'k8s.io/component-base/version.gitMajor=1'",
-        "-X 'k8s.io/component-base/version.gitMinor=30'",
-        "-X 'k8s.io/component-base/version.gitVersion=v1.30.0'",
-        "-X 'k8s.io/component-base/version.gitCommit=a06568062c41b4f0f903dcb78aa6ea348bbdecfc'"
+        "-X 'k8s.io/component-base/version.gitMinor=33'",
+        "-X 'k8s.io/component-base/version.gitVersion=v1.33.0'",
+        "-X 'k8s.io/component-base/version.gitCommit=60a317eadfcb839692a68eab88b2096f4d708f4f'"
     )
 
     Push-Location "$RepoPath"


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/windows-testing/issues/503

kubeadm SupportedEtcdVersion:

![image](https://github.com/user-attachments/assets/3ec86f7c-542c-4e2e-a94f-2d1739aa0f48)

![image](https://github.com/user-attachments/assets/18176d9e-6482-4116-9824-ea36ff188842)

