### PR TITLE
use fix vm size instead of dynamic ones

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -187,6 +187,7 @@ create_cluster(){
                 --resource-group "${CLUSTER_NAME}" \
                 --name "${CLUSTER_NAME}" \
                 --node-count 1 \
+                --node-vm-size Standard_D2s_v2 \
                 --generate-ssh-keys \
                 --vm-set-type VirtualMachineScaleSets \
                 --kubernetes-version 1.31.3 \


### PR DESCRIPTION
This is becuase some of the dynamically picked vm size does not exit in some of the azure regions used by test