### PR TITLE
Update calico version to 3.30.0 from 3.29.2

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -28,7 +28,7 @@ main() {
     export GMSA="${GMSA:-""}" 
     export HYPERV="${HYPERV:-""}"
     export KPNG="${WINDOWS_KPNG:-""}"
-    export CALICO_VERSION="${CALICO_VERSION:-"v3.29.2"}"
+    export CALICO_VERSION="${CALICO_VERSION:-"v3.30.0"}"
     export TEMPLATE="${TEMPLATE:-"windows-ci.yaml"}"
     export CAPI_VERSION="${CAPI_VERSION:-"v1.7.2"}"
     export HELM_VERSION=v3.15.2


### PR DESCRIPTION
## PR Description

### Reason for Upgrading Calico from v3.29.2 to v3.30.0

We are upgrading Calico to version **v3.30.0** to incorporate critical dependency updates and maintain compatibility with upstream container networking components.

### Dependency Comparison

#### Calico Dependency Versions

| Dependency                  | Calico v3.29.2 | Calico v3.30.0 |
| -------------------------------- | -------------- | -------------- |
| **Microsoft hcsshim**            | `v0.11.8`      | `v0.12.9`      |
| **Container Networking Plugins** |                |                |
|    `containernetworking/cni`     | `v1.2.0`       | `v1.2.3`       |
|    `containernetworking/plugins` | `v1.1.1`       | `v1.6.2`       |

#### Container Networking Plugins

| Dependency                | `master` | `v1.7.1` |  `v1.6.2` |
| ------------------------- | -------- | -------- | -------- |
| `hcsshim`                 | `v0.13.0`  | `v0.12.9`  | `v0.12.9`  |
| `containernetworking/cni` | `v1.3.0`   | `v1.3.0`   |`v1.2.3`   |

### :exclamation: Important Note

There have been changes in **[tiered policy naming changes](https://github.com/projectcalico/calico/blob/v3.29.4/release-notes/v3.29.4-release-notes.md#tiered-policy-naming-changes)** introduced in Calico **v3.29.4**, which may impact policy definitions or enforcement in your current configuration. See [Calico v3.29.4 Release Notes](https://github.com/projectcalico/calico/blob/v3.29.4/release-notes/v3.29.4-release-notes.md#tiered-policy-naming-changes)
