### PR TITLE
Fixing hangs in windows unit test jobs

### DIFF
--- a/scripts/ci-k8s-common.sh
+++ b/scripts/ci-k8s-common.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SSH_OPTS="-o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=3 -o TCPKeepAlive=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH_OPTS_LONG="-o ServerAliveInterval=10 -o ServerAliveCountMax=12 -o ConnectTimeout=30 -o TCPKeepAlive=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
 function onError(){
     az group list | jq ' .[] | .name' | grep ${AZURE_RESOURCE_GROUP}
     if [ $? -eq 0 ]; then

--- a/scripts/ci-k8s-unit-test.sh
+++ b/scripts/ci-k8s-unit-test.sh
@@ -5,7 +5,6 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-SSH_OPTS="-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 PROW_BUILD_ID="${BUILD_ID:-000000000000}"
 AZURE_RESOURCE_GROUP="win-unit-test-${PROW_BUILD_ID}"
 AZURE_DEFAULT_IMG="MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
@@ -24,7 +23,21 @@ SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPT_ROOT=$(dirname "${SCRIPT_PATH}")
 source ${SCRIPT_ROOT}/ci-k8s-common.sh
 
-trap onError ERR 
+trap onError ERR
+
+function copy_logs {
+    echo "Copying c:/Logs/*.xml from ${VM_PUB_IP}:c:/Logs/*.xml to ${ARTIFACTS}"
+    scp -i ${SSH_KEY_FILE} ${SSH_OPTS} azureuser@${VM_PUB_IP}:"c:/Logs/*.xml" ${ARTIFACTS}
+    echo "Copying c:/Logs/*.log from ${VM_PUB_IP}:c:/Logs/*.log to ${ARTIFACTS}"
+    scp -i ${SSH_KEY_FILE} ${SSH_OPTS} azureuser@${VM_PUB_IP}:"c:/Logs/*.log" ${ARTIFACTS}
+}
+
+function destroy_resource_group_and_exit {
+    local exit_code=$1
+    copy_logs
+    destroy_resource_group
+    exit $exit_code
+}
 
 ensure_azure_cli
 build_resource_group
@@ -65,17 +78,17 @@ then
         test_packages_arg="-testPackages ${TEST_PACKAGES}"
     fi
 
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_unit_windows.ps1 ${skip_arg} -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
+    # Use SSH_OPTS_LONG for the resource-intensive command
+    ssh -i ${SSH_KEY_FILE} ${SSH_OPTS_LONG} azureuser@${VM_PUB_IP} "c:/k8s_unit_windows.ps1 ${skip_arg} -repoName ${REPO_NAME} -repoOrg ${REPO_OWNER} -pullRequestNo ${PULL_NUMBER} -pullBaseRef ${PULL_BASE_REF} ${test_packages_arg}"
     exit_code=$?
 else
     echo "Running periodic job"
-    run_remote_cmd ${VM_PUB_IP} ${SSH_KEY_FILE} "c:/k8s_unit_windows.ps1 ${skip_arg}"
+    # Use SSH_OPTS_LONG for the resource-intensive command
+    ssh -i ${SSH_KEY_FILE} ${SSH_OPTS_LONG} azureuser@${VM_PUB_IP} "c:/k8s_unit_windows.ps1 ${skip_arg}"
     exit_code=$?
 fi
 set -e  # Re-enable errexit
 trap onError ERR  # Re-enable the ERR trap
 
-copy_from 'c:/Logs/*.xml' ${ARTIFACTS} ${VM_PUB_IP}
-destroy_resource_group
+destroy_resource_group_and_exit $exit_code
 
-exit $exit_code

--- a/scripts/k8s_unit_windows.ps1
+++ b/scripts/k8s_unit_windows.ps1
@@ -1,6 +1,6 @@
 param (
-    [string]$repoName = "kubernetes", 
-    [string]$repoOrg = "kubernetes",    
+    [string]$repoName = "kubernetes",
+    [string]$repoOrg = "kubernetes",
     [string]$pullRequestNo,
     [string]$pullBaseRef = "master",
     [string[]]$testPackages = @(),
@@ -16,7 +16,7 @@ $EXTRA_PACKAGES = @("./cmd/...")
 $EXCLUDED_PACKAGES = @(
     "./pkg/proxy/iptables/...",
     "./pkg/proxy/ipvs/...",
-    "./pkg/proxy/nftables/...") 
+    "./pkg/proxy/nftables/...")
 # Map of packages with test case names to skip.
 $SkipTestsForPackage = @{
     "./cmd/..."         = @(
@@ -53,6 +53,9 @@ $SkipTestsForPackage = @{
         "TestPlugin",
         "TestPluginOptionalKeys"
     )
+    "./pkg/routes/..." = @(
+        "TestPreCheckLogFileNameLength"
+    )
 }
 
 function Prepare-TestPackages {
@@ -61,18 +64,15 @@ function Prepare-TestPackages {
     }
 
     Push-Location "$RepoPath/pkg"
-    $packages = ls -Directory  | select Name | foreach { "./pkg/" + $_.Name + "/..." }
+    $packages = ls -Directory | select Name | foreach { "./pkg/" + $_.Name + "/..." }
     $packages = $packages + $EXTRA_PACKAGES
     $EXCLUDED_PACKAGES | foreach { $packages = $packages -ne $_ }
     Pop-Location
     return $packages
-
 }
 
 function Prepare-LogsDir {
-    
     mkdir $LogsDirPath
-
 }
 
 function Clone-TestRepo {
@@ -93,7 +93,6 @@ function Clone-TestRepo {
 }
 
 function Install-Tools {
-
     Write-Host "Install testing tools"
     Push-Location "$RepoPath/hack/tools"
     go install gotest.tools/gotestsum
@@ -102,16 +101,13 @@ function Install-Tools {
     Push-Location "$RepoPath/cmd/prune-junit-xml"
     go install .
     Pop-Location
-
 }
 
 function Prepare-Vendor {
-    
     Write-Host "Downloading vendor files"
     Push-Location "$RepoPath"
     go mod vendor
     Pop-Location
-
 }
 
 function Get-VersionLdflags {
@@ -173,86 +169,259 @@ function Build-Kubeadm {
 }
 
 function Run-K8sUnitTests {
+    # Set GOMAXPROCS globally for the entire machine/session
+    $env:GOMAXPROCS = 4
+    [Environment]::SetEnvironmentVariable("GOMAXPROCS", "4", "Process")
+    Write-Host "Set GOMAXPROCS=4 globally for this session"
+    Write-Host "Verification: GOMAXPROCS = $env:GOMAXPROCS"
+    
+    # Limit parallel jobs to prevent CPU oversubscription
+    $maxParallelJobs = 4
+    $jobs = New-Object System.Collections.ArrayList
+    $failedPackages = New-Object System.Collections.ArrayList
+    $packageIndex = 0
 
-    $jobs = @()
+    Write-Host "Total packages to test: $($TEST_PACKAGES.Count)"
+    Write-Host "TEST_PACKAGES contents: $TEST_PACKAGES"
 
-    for ($index = 0; $index -lt $TEST_PACKAGES.Count; $index++) {
-        $package = $TEST_PACKAGES[$index]
-        $junit_output_file = Join-Path -Path $LogsDirPath -ChildPath ("{0}_{1}.xml" -f $JUNIT_FILE_NAME, $index)
+    while ($packageIndex -lt $TEST_PACKAGES.Count -or $jobs.Count -gt 0) {
+        # Start new jobs up to the limit
+        while ($jobs.Count -lt $maxParallelJobs -and $packageIndex -lt $TEST_PACKAGES.Count) {
+            Write-Host ">>> Starting new job: jobs.Count=$($jobs.Count), packageIndex=$packageIndex"
+            [Console]::Out.Flush()
+            $package = $TEST_PACKAGES[$packageIndex]
+            Write-Host "INFO: packageIndex=$packageIndex, package retrieved='$package'"
+            $junit_output_file = Join-Path -Path $LogsDirPath -ChildPath ("{0}_{1}.xml" -f $JUNIT_FILE_NAME, $packageIndex)
 
-        $testsToSkip = $null
-        if ($SkipFailingTests -and $SkipTestsForPackage.ContainsKey($package)) {
-            $testsToSkip = $SkipTestsForPackage[$package] -join "|"
-            Write-Output "Skipping tests for package: $package, tests: $testsToSkip"
-        } else {
-            Write-Output "Not skipping any tests for package: $package"
-        }
-
-        
-        Write-Output "Starting job to run tests for package: $package"
-        $jobs += Start-Job -ScriptBlock {
-            param($pkg, $outputFile, $RepoPath, $skipRegex)
-
-            Push-Location "$RepoPath"
-	        $args = @(
-		        "--junitfile=$outputFile",
-		        "--packages=`"$pkg`""
-            )
-	        if ($skipRegex) {
-		        $args += "--"
-		        $args += "--skip"
-		        $args += $skipRegex
+            $testsToSkip = $null
+            if ($SkipFailingTests -and $SkipTestsForPackage.ContainsKey($package)) {
+                $testsToSkip = $SkipTestsForPackage[$package] -join "|"
+                Write-Output "Skipping tests for package: $package, tests: $testsToSkip"
+            } else {
+                Write-Output "Not skipping any tests for package: $package"
             }
 
-            Push-Location "$RepoPath"
-            # Collect output in an array.
-            $outputLines = @()
-            $outputLines += "Running unit tests for package: $pkg :: gotestsum.exe " + ($args -join ' ')
-            $cmdOutput = & gotestsum.exe @args 2>&1
-            $outputLines += $cmdOutput
-            $exitCode = $LASTEXITCODE
-            $combinedOutput = $outputLines -join "`n"
-            & prune-junit-xml.exe $outputFile
+            Write-Output "Starting job to run tests for package: $package ($($packageIndex + 1) of $($TEST_PACKAGES.Count))"
+            [Console]::Out.Flush()
+            
+            $job = Start-Job -ScriptBlock {
+                param($package, $junitIndex, $repoPath, $testsToSkip)
 
-            [PSCustomObject]@{
-                Package  = $pkg
-                ExitCode = $exitCode
-                Output   = $combinedOutput
+                Set-Location $repoPath
+
+                $env:GOMAXPROCS = 4
+                Write-Host "Job starting for package: $package from $(Get-Location)"
+
+                $junitFile = "c:\Logs\junit_$($junitIndex).xml"
+                $logFile = "c:\Logs\output_$($junitIndex).log"
+                $command = "gotestsum.exe"
+                
+                # Build arguments array like the original
+                $args = @(
+                    "--junitfile=$junitFile",
+                    "--packages=`"$package`""
+                )
+                
+                # Add skip tests if specified (using the original logic)
+                if ($testsToSkip) {
+                    Write-Host "Adding skip arguments for tests: $testsToSkip"
+                    $args += "--"
+                    $args += "--skip"
+                    # Escape pipe characters for cmd.exe
+                    $escapedTests = $testsToSkip -replace '\|', '^|'
+                    $args += "`"$escapedTests`""
+                }
+                
+                # Convert args array to string for cmd.exe
+                $arguments = $args -join " "
+                
+                Write-Host "Running unit tests for package: $package :: $command $arguments"
+                
+                # Log the command line to the output file first
+                "Running unit tests for package: $package :: $command $arguments" | Out-File -FilePath $logFile -Encoding UTF8
+                "=== TEST START ===" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                "Job started at: $(Get-Date)" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                
+                # Use cmd.exe with file redirection to avoid PowerShell buffer issues
+                # which cause a hang if output buffers fill up
+                Write-Host "About to run: $command $arguments"
+                "About to run: $command $arguments at $(Get-Date)" | Out-File -FilePath $logFile -Append -Encoding UTF8
+
+                # Create temporary output file
+                $tempOutputFile = "$logFile.temp"
+
+                # Use cmd.exe to redirect output directly to file, avoiding PowerShell buffers
+                $cmdLine = "cmd.exe /c $command $arguments > `"$tempOutputFile`" 2>&1"
+                "Starting process at: $(Get-Date)" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                "Command line: $cmdLine" | Out-File -FilePath $logFile -Append -Encoding UTF8
+
+                # Use Invoke-Expression to run the cmd command
+                try {
+                    Invoke-Expression $cmdLine
+                    $exitCode = $LASTEXITCODE
+                    if (-not $exitCode) { $exitCode = 0 }
+                    
+                    Write-Host "Process completed with exit code: $exitCode"
+                    "Process completed with exit code: $exitCode at: $(Get-Date)" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                } catch {
+                    Write-Host "Error running command: $_"
+                    "Error running command: $_ at: $(Get-Date)" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                    $exitCode = 1
+                }
+                
+                # Read the output file
+                $output = ""
+                if (Test-Path $tempOutputFile) {
+                    try {
+                        $output = Get-Content $tempOutputFile -Raw
+                        # Remove the temp file
+                        Remove-Item $tempOutputFile -ErrorAction SilentlyContinue
+                    } catch {
+                        Write-Host "Error reading output file: $_"
+                        "Error reading output file: $_" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                        $output = "Error reading output file: $_"
+                    }
+                } else {
+                    $output = "No output file created"
+                }
+                
+                Write-Host "Command completed with exit code: $exitCode"
+                
+                # Write combined output to main log file
+                if ($output) {
+                    $output | Out-File -FilePath $logFile -Append -Encoding UTF8
+                }
+                "Exit code: $exitCode" | Out-File -FilePath $logFile -Append -Encoding UTF8
+                "Job completed at: $(Get-Date)" | Out-File -FilePath $logFile -Append -Encoding UTF8
+
+                # Check if log file exists and get its size
+                if (Test-Path $logFile) {
+                    $logSize = (Get-Item $logFile).Length
+                    Write-Host "Log file size: $logSize bytes"
+                } else {
+                    Write-Host "ERROR: Log file not found!"
+                    $logSize = 0
+                }
+
+                return [PSCustomObject]@{
+                    Package    = $package
+                    Output     = "See log file: $logFile (size: $logSize bytes)"
+                    ExitCode   = $exitCode
+                }
+            } -ArgumentList $package, $packageIndex, $RepoPath, $testsToSkip
+
+            if ($job) {
+                $job.Name = "UnitTest-$package"
+                [void]$jobs.Add($job)
+                Write-Host ">>> Job started with ID: $($job.Id), Name: $($job.Name)"
+            } else {
+                Write-Host "ERROR: Failed to create job for package: $package"
+                [void]$failedPackages.Add("FAILED_TO_CREATE_JOB: $package")
             }
-        } -ArgumentList $package, $junit_output_file, $RepoPath, $testsToSkip
-    }
+            [Console]::Out.Flush()
 
-    $failedJobCount = 0 
-    while ($jobs.Count -gt 0) {
-        $finishedJob = Wait-Job -Job $jobs -Any
-        $result = Receive-Job -Job $finishedJob
-        
-        if ($result.ExitCode -ne 0) {
-            $failedJobCount++
+            $packageIndex++
         }
-    
-        Write-Output "Output for package: $($result.Package)"
-        Write-Output $result.Output
-        Write-Output "Exit code: $($result.ExitCode)"
-        Write-Output ("-" * 40)
-    
-        $jobs = $jobs | Where-Object { $_.Id -ne $finishedJob.Id }
-        Write-Output "Waiting for $($jobs.Count) more jobs to complete"
-        Write-Output ("-" * 40)
+
+        # Wait for jobs to finish
+        if ($jobs.Count -gt 0) {
+            Write-Host ">>> Waiting for at least one job to complete... ($($jobs.Count) active jobs)"
+            [Console]::Out.Flush()
+            
+            $waitCounter = 0
+            # Continuously check for completed jobs until at least one is found
+            while (($jobs | Where-Object { $_.State -in @('Completed', 'Faulted') }).Count -eq 0 -and $jobs.Count -gt 0) {
+                Start-Sleep -Seconds 1
+                $waitCounter++
+                if (($waitCounter % 30) -eq 0) {
+                    Write-Host "INFO: Still waiting for jobs to complete after $waitCounter seconds. Current job states:"
+                    $jobs | ForEach-Object { Write-Host "  - Job ID: $($_.Id), Name: $($_.Name), State: $($_.State)" }
+                }
+            }
+        }
+
+        $completedJobs = $jobs | Where-Object { $_.State -in @('Completed', 'Faulted') }
+
+        if ($completedJobs.Count -gt 0) {
+            Write-Host "Found $($completedJobs.Count) completed/faulted job(s) to process."
+        }
+
+        $jobsToRemove = @()
+        foreach ($finishedJob in $completedJobs) {
+            Write-Host "Receiving job results for job $($finishedJob.Id) (State: $($finishedJob.State))..."
+            if ($finishedJob.State -eq 'Faulted') {
+                Write-Host "Job $($finishedJob.Id) has faulted. Error:"
+                $finishedJob.ChildJobs[0].JobStateInfo.Reason.Message | Write-Host
+                [void]$failedPackages.Add("FAULTED_JOB: $($finishedJob.Name)")
+            } else {
+                $result = Receive-Job -Job $finishedJob
+                
+                # Extract package name properly, handling both array and object cases
+                $packageName = $result.Package
+                if ($packageName -is [array]) {
+                    $packageName = $packageName[0]
+                }
+                # Clean up whitespace and ensure it's a string
+                $packageName = [string]$packageName
+                $packageName = $packageName.Trim()
+                
+                # Additional safety check for empty/null values
+                if ([string]::IsNullOrWhiteSpace($packageName)) {
+                    $packageName = "UNKNOWN_PACKAGE_$($finishedJob.Id)"
+                }
+                
+                Write-Host "Job result received. Package: $packageName, ExitCode: $($result.ExitCode)"
+
+                Write-Host "Output for package: $packageName"
+                Write-Host $result.Output
+                Write-Host "----------------------------------------"
+
+                if ($result.ExitCode -ne 0) {
+                    Write-Host "Adding failed package to results: '$packageName' (exit code: $($result.ExitCode))"
+                    [void]$failedPackages.Add($packageName)
+                } else {
+                    Write-Host "Package '$packageName' passed (exit code: $($result.ExitCode))"
+                }
+            }
+
+            Write-Host "Cleaning up job $($finishedJob.Id)..."
+            Remove-Job -Job $finishedJob
+            $jobsToRemove += $finishedJob
+
+            Write-Host "Active jobs: $($jobs.Count), Remaining packages: $($TEST_PACKAGES.Count - $packageIndex)"
+            Write-Host "----------------------------------------"
+        }
+        
+        # Remove all processed jobs from the collection at once
+        $jobsToRemove | ForEach-Object { [void]$jobs.Remove($_) }
     }
 
-    if ($failedJobCount) {
+    Write-Host "All packages have been processed. Final job cleanup..."
+    $remainingSystemJobs = Get-Job
+    if ($remainingSystemJobs) {
+        Write-Host "Cleaning up remaining background jobs: $($remainingSystemJobs.Count)"
+        $remainingSystemJobs | Remove-Job -Force
+    }
+    
+    if ($failedPackages.Count -gt 0) {
+        Write-Host "Exiting with code 1 due to $($failedPackages.Count) failed packages: $($failedPackages -join ', ')"
         exit 1
     }
     else {
+        Write-Host "Exiting with code 0 - all tests passed"
         exit 0
     }
 }
 
+# Main script execution
 Prepare-LogsDir
 Clone-TestRepo
 Prepare-Vendor
 Build-Kubeadm
 Install-Tools
-$TEST_PACKAGES = Prepare-TestPackages
+
+Write-Host "DEBUG: Before calling Prepare-TestPackages"
+$TEST_PACKAGES = @(Prepare-TestPackages)
+Write-Host "DEBUG: After Prepare-TestPackages, TEST_PACKAGES = $TEST_PACKAGES (Count: $($TEST_PACKAGES.Count), Type: $($TEST_PACKAGES.GetType().Name))"
+
 Run-K8sUnitTests


### PR DESCRIPTION
Fixing hangs in windows unit test jobs by doing a couple of things,

- Running each gotestsum.exe instance with cmd.exe and logging to a file - Occasionally powershell jobs are hanging because the input buffers are filling up and doing realtime reads from without powershell jobs is unreliable
- Limiting parallelism in job (both by setting GOMAXPROC env and also only running up to 4 instances of gotestsum.exe at the same time.
- updating ssh connection timeout options to be more resiliant

This doesn't look like it is slowing down the overall job duration at all