### PR TITLE
Fix unit test issue where az vm run-command isn't running anymore

### DIFF
--- a/scripts/ci-k8s-common.sh
+++ b/scripts/ci-k8s-common.sh
@@ -14,25 +14,35 @@ function onError(){
 
 ensure_azure_cli() {
     if [[ -z "$(command -v az)" ]]; then
-        echo "installing Azure CLI"
+        echo "installing Azure CLI v2.76.0"
         apt-get update && apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
         curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
         AZ_REPO=$(lsb_release -cs)
         echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${AZ_REPO} main" | tee /etc/apt/sources.list.d/azure-cli.list
-        apt-get update && apt-get install -y azure-cli
-  	
-        if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
-            echo "Logging in with federated token"
-            # AZURE_CLIENT_ID has been overloaded with Azure Workload ID in the preset-azure-cred-wi.
-            # This is done to avoid exporting Azure Workload ID as AZURE_CLIENT_ID in the test scenarios.
-            az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" > /dev/null
-
-            # Use --auth-mode "login" in az storage commands to use RBAC permissions of login identity. This is a well known ENV variable the Azure cli
-            export AZURE_STORAGE_AUTH_MODE="login"
+        apt-get update && apt-get install -y azure-cli=2.76.0-1~${AZ_REPO}
+    else
+        # Check if we have the correct version
+        CURRENT_VERSION=$(az version --query '."azure-cli"' -o tsv 2>/dev/null || echo "unknown")
+        REQUIRED_VERSION="2.76.0"
+        if [[ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]]; then
+            echo "Warning: Azure CLI version is $CURRENT_VERSION, but $REQUIRED_VERSION is required"
+            echo "Consider running: apt-get install -y azure-cli=${REQUIRED_VERSION}-1~$(lsb_release -cs)"
         else
-            echo "AZURE_FEDERATED_TOKEN_FILE environment variable must be set to path location of token file"
-            exit 1
+            echo "Azure CLI version $CURRENT_VERSION is correct"
         fi
+    fi
+    
+    if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+        echo "Logging in with federated token"
+        # AZURE_CLIENT_ID has been overloaded with Azure Workload ID in the preset-azure-cred-wi.
+        # This is done to avoid exporting Azure Workload ID as AZURE_CLIENT_ID in the test scenarios.
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" > /dev/null
+
+        # Use --auth-mode "login" in az storage commands to use RBAC permissions of login identity. This is a well known ENV variable the Azure cli
+        export AZURE_STORAGE_AUTH_MODE="login"
+    else
+        echo "AZURE_FEDERATED_TOKEN_FILE environment variable must be set to path location of token file"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
I think when the az cli 2.78.0 started getting installed by default it caused a regression.
I will look into the issue after this merged.