### PR TITLE
Let tigera-operator helm chart add kubernetes-service-endpoin configMap-

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -289,26 +289,16 @@ apply_workload_configuraiton(){
     if [[ "${IS_PRESUBMIT}" == "true" ]]; then
         sleep 30s
     fi
-    "$TOOLS_BIN_DIR"/helm upgrade calico projectcalico/tigera-operator --version "$CALICO_VERSION" --namespace tigera-operator -f "$SCRIPT_ROOT"/templates/calico/values.yaml  --create-namespace  --install --debug
-    timeout --foreground 300 bash -c "until kubectl get ipamconfigs default -n default > /dev/null 2>&1; do sleep 3; done"
-
-    #required for windows no way to do it via operator https://github.com/tigera/operator/issues/3113
-    kubectl patch ipamconfigs default --type merge --patch='{"spec": {"strictAffinity": true}}'
 
     # get the info for the API server
     servername=$(kubectl config view -o json | jq -r '.clusters[0].cluster.server | sub("https://"; "") | split(":") | .[0]')
     port=$(kubectl config view -o json | jq -r '.clusters[0].cluster.server | sub("https://"; "") | split(":") | .[1]')
 
-    kubectl apply -f - << EOF
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: kubernetes-services-endpoint
-  namespace: tigera-operator
-data:
-  KUBERNETES_SERVICE_HOST: "${servername}"
-  KUBERNETES_SERVICE_PORT: "${port}"
-EOF
+    "$TOOLS_BIN_DIR"/helm upgrade calico projectcalico/tigera-operator --version "$CALICO_VERSION" --namespace tigera-operator -f "$SCRIPT_ROOT"/templates/calico/values.yaml  --create-namespace  --install --debug --set kubernetesServiceEndpoint.host="${servername}" --set kubernetesServiceEndpoint.port="${port}"
+    timeout --foreground 300 bash -c "until kubectl get ipamconfigs default -n default > /dev/null 2>&1; do sleep 3; done"
+
+    #required for windows no way to do it via operator https://github.com/tigera/operator/issues/3113
+    kubectl patch ipamconfigs default --type merge --patch='{"spec": {"strictAffinity": true}}'
 
     # Only patch up kube-proxy if $WINDOWS_KPNG is unset
     if [[ -z "$KPNG" ]]; then


### PR DESCRIPTION
https://github.com/projectcalico/calico/pull/8443 adds support for letting the tigera-operator helm chart create the kubernetes-service-endpoints configMap