### PR TITLE
capz: avoid `azurecluster`  for bastion endpoint resolution in favor of native `cluster` resource

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -264,9 +264,22 @@ create_cluster(){
         log "cluster creation complete"
     fi
 
+    log "wait for "${CLUSTER_NAME}" cluster to stabilize"
+    timeout --foreground 300 bash -c "until kubectl get --raw /version --request-timeout 5s > /dev/null 2>&1; do sleep 3; done"
+
+    CLUSTER_JSON=$(kubectl get cluster "${CLUSTER_NAME}" -n default -o json || true)
+    if [[ -z "${CLUSTER_JSON}" ]]; then
+        log "ERROR: failed to get cluster "${CLUSTER_NAME}" in namespace default"
+        exit 1
+    fi
+    BASTION_ADDRESS=$(echo "${CLUSTER_JSON}" | jq -r '.spec.controlPlaneEndpoint.host // empty')
+    if [[ -z "${BASTION_ADDRESS}" ]]; then
+        log "ERROR: bastion address lookup failed for cluster"
+        echo "${CLUSTER_JSON}"
+        exit 1
+    fi
     # set the SSH bastion that can be used to SSH into nodes
-    KUBE_SSH_BASTION=$(kubectl get azurecluster -o json | jq '.items[0].spec.networkSpec.apiServerLB.frontendIPs[0].publicIP.dnsName' | tr -d \"):22
-    export KUBE_SSH_BASTION
+    export KUBE_SSH_BASTION="${BASTION_ADDRESS}:22"
     KUBE_SSH_USER=capi
     export KUBE_SSH_USER
     log "bastion info: $KUBE_SSH_USER@$KUBE_SSH_BASTION"
@@ -282,7 +295,7 @@ create_cluster(){
 apply_workload_configuraiton(){
     log "wait for cluster to stabilize"
     timeout --foreground 300 bash -c "until kubectl get --raw /version --request-timeout 5s > /dev/null 2>&1; do sleep 3; done"
-    
+
     log "installing calico"
     "$TOOLS_BIN_DIR"/helm repo add projectcalico https://docs.tigera.io/calico/charts
     kubectl create ns calico-system


### PR DESCRIPTION
this PR addresses the resolution of the bastion endpoint by first hitting the provider-agnostic representation of the k8s cluster managed by CAPI to resolve the API server endpoint.

Just relying on `kubectl get azurecluster` for the bastion endpoint is brittle, as AzureCluster.spec may not contain the endpoint until CAPZ finishes provisioning and updates the field; if checked too early, it will be empty.

Fixes 
- https://github.com/kubernetes/kubernetes/issues/126090
```
  ...
  Wed, 29 Oct 2025 02:20:02 +0000: bastion info: capi@null:22
  ...
  I1029 02:48:45.319519 5359 kubelet.go:778] Unexpected error: 
      <*fmt.wrapError | 0xc000e67ba0>: 
      error getting SSH client to capi@null:22: dial tcp: lookup null on 172.20.0.10:53: no such host
      {
          msg: "error getting SSH client to capi@null:22: dial tcp: lookup null on 172.20.0.10:53: no such host",
          err: <*net.OpError | 0xc002e1a280>{
              Op: "dial",
              Net: "tcp",
              Source: nil,
              Addr: nil,
              Err: <*net.DNSError | 0xc002e1a230>{
                  UnwrapErr: nil,
                  Err: "no such host",
                  Name: "null",
                  Server: "172.20.0.10:53",
                  IsTimeout: false,
                  IsTemporary: false,
                  IsNotFound: true,
              },
          },
      }
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-capz-master-windows-alpha/1983355350576795648#1:build-log.txt%3A198

