### PR TITLE
Try to upgrade calico to 3.31

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -28,7 +28,7 @@ main() {
     export GMSA="${GMSA:-""}" 
     export HYPERV="${HYPERV:-""}"
     export KPNG="${WINDOWS_KPNG:-""}"
-    export CALICO_VERSION="${CALICO_VERSION:-"v3.29.2"}"
+    export CALICO_VERSION="${CALICO_VERSION:-"v3.31.0"}"
     export TEMPLATE="${TEMPLATE:-"windows-ci.yaml"}"
     export CAPI_VERSION="${CAPI_VERSION:-"v1.7.2"}"
     export HELM_VERSION=v3.15.2

--- a/capz/templates/calico/values.yaml
+++ b/capz/templates/calico/values.yaml
@@ -13,6 +13,13 @@ installation:
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator
-  registry: mcr.microsoft.com/oss
+  registry: capzcicommunity.azurecr.io
 calicoctl:
-  image: mcr.microsoft.com/oss/calico/ctl
+  image: capzcicommunity.azurecr.io/calico/ctl
+# when kubernetesServiceEndpoint need to pass dns to look up the name properly
+dnsConfig: 
+  nameservers:
+    - 127.0.0.53
+  options:
+    - name: edns0
+    - name: trust-ad


### PR DESCRIPTION
This is based on https://github.com/kubernetes-sigs/windows-testing/pull/521, while we have met with issue for calico related pod on linux node.but the system pods such as calico-apiserver and calico-node pods are failing on linux node, while the calico-node* related pos are in running state on windows node. it looks hat during the installation of calico/cni, it will need to call DNS to reach to apiserver, while the coreDNS pod, without the cni being set up, will not be able to properly SNAT its request so it failed to request to upstream DNS.
 
the workaround here is to use ipaddress instead of the servername to calico-node to break this kind of deadlock. 
 