### PR TITLE
Fixing issue where  is used in test-path but not set

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -67,7 +67,8 @@ spec:
             Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
             # Check if kube-log-runner.exe exists
-            if (Test-Path $kubeloggerPath) {
+            $kubeloggerPath = Join-Path $env:SYSTEMDRIVE "k\kube-log-runner.exe"
+            if ($kubeloggerPath -and (Test-Path -Path $kubeloggerPath)) {
               Write-Output "Recreating containerd service with kube-log-runner..."
               $logPath = "\var\log\containerd"
               # Check if directory exists

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -67,7 +67,8 @@ spec:
             Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
             # Check if kube-log-runner.exe exists
-            if (Test-Path $kubeloggerPath) {
+            $kubeloggerPath = Join-Path $env:SYSTEMDRIVE "k\kube-log-runner.exe"
+            if ($kubeloggerPath -and (Test-Path -Path $kubeloggerPath)) {
               Write-Output "Recreating containerd service with kube-log-runner..."
               $logPath = "\var\log\containerd"
               # Check if directory exists

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -67,7 +67,8 @@ spec:
             Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
             # Check if kube-log-runner.exe exists
-            if (Test-Path $kubeloggerPath) {
+            $kubeloggerPath = Join-Path $env:SYSTEMDRIVE "k\kube-log-runner.exe"
+            if ($kubeloggerPath -and (Test-Path -Path $kubeloggerPath)) {
               Write-Output "Recreating containerd service with kube-log-runner..."
               $logPath = "\var\log\containerd"
               # Check if directory exists

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -67,7 +67,8 @@ spec:
             Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
             # Check if kube-log-runner.exe exists
-            if (Test-Path $kubeloggerPath) {
+            $kubeloggerPath = Join-Path $env:SYSTEMDRIVE "k\kube-log-runner.exe"
+            if ($kubeloggerPath -and (Test-Path -Path $kubeloggerPath)) {
               Write-Output "Recreating containerd service with kube-log-runner..."
               $logPath = "\var\log\containerd"
               # Check if directory exists

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -67,7 +67,8 @@ spec:
             Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
             # Check if kube-log-runner.exe exists
-            if (Test-Path $kubeloggerPath) {
+            $kubeloggerPath = Join-Path $env:SYSTEMDRIVE "k\kube-log-runner.exe"
+            if ($kubeloggerPath -and (Test-Path -Path $kubeloggerPath)) {
               Write-Output "Recreating containerd service with kube-log-runner..."
               $logPath = "\var\log\containerd"
               # Check if directory exists

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -67,7 +67,8 @@ spec:
             Write-Output "Extracting new containerd binaries"
             tar.exe -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
             # Check if kube-log-runner.exe exists
-            if (Test-Path $kubeloggerPath) {
+            $kubeloggerPath = Join-Path $env:SYSTEMDRIVE "k\kube-log-runner.exe"
+            if ($kubeloggerPath -and (Test-Path -Path $kubeloggerPath)) {
               Write-Output "Recreating containerd service with kube-log-runner..."
               $logPath = "\var\log\containerd"
               # Check if directory exists


### PR DESCRIPTION
fixing 

```log
0\r100 33.9M  100 33.9M    0     0  58.1M      0 --:--:-- --:--:-- --:--:--  123M\r\nx containerd.exe\r\nx containerd-stress.exe\r\nx ctr.exe\r\nx containerd-shim-runhcs-v1.exe\r\nTest-Path : Cannot bind argument to parameter \'Path\' because it is null.\r\nAt C:\\replace-containerd.ps1:43 char:17\r\n+   if (Test-Path $kubeloggerPath) {\r\n+                 ~~~~~~~~~~~~~~~\r\n    + CategoryInfo          : InvalidData: (:) [Test-Path], ParentContainsErrorRecordException\r\n    + FullyQualifiedError
```
from https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-capz-master-windows/1985705713594273792/artifacts/clusters/capz-conf-65b8ih/machines/capz-conf-65b8ih-md-win-mmm9k-mqgz4/cloudbase-init.log