### PR TITLE
Fix Hyper-V webhook: restore objectSelector and skip hostNetwork pods

### DIFF
--- a/helpers/helm/values-hyperv.yaml
+++ b/helpers/helm/values-hyperv.yaml
@@ -47,9 +47,7 @@ deployment:
 
 webhookConfiguration:
   path: /mutate-v1-pod
-  objectSelector:
-    matchLabels:
-      hyperv-isolation: "true"
+  objectSelector: {}
 
 # RuntimeClass configuration for Hyper-V
 runtimeClass:

--- a/helpers/hyper-v-mutating-webhook/webhook.go
+++ b/helpers/hyper-v-mutating-webhook/webhook.go
@@ -54,7 +54,14 @@ func (pu *podUpdater) Handle(ctx context.Context, req admission.Request) admissi
 	if isHostProcessPod(pod) {
 		mutatePod = false
 	}
-	
+
+	// Don't apply hyper-v runtime class to hostNetwork pods, as Hyper-V
+	// isolation runs containers inside a utility VM with its own network
+	// namespace which is incompatible with host networking
+	if pod.Spec.HostNetwork {
+		mutatePod = false
+	}
+
 	// Don't apply hyper-v runtime class for linux pods that are explicitly labeled, as this is a windows only supported runtimeclass
 	if osLabel, ok := pod.Spec.NodeSelector["kubernetes.io/os"]; ok && osLabel == "linux" {
 		mutatePod = false


### PR DESCRIPTION
## What this PR does

Fixes two bugs in the Hyper-V mutating admission webhook:

### 1. objectSelector regression (values-hyperv.yaml)

The Helm migration in PR #533 and #546 introduced `objectSelector: matchLabels: hyperv-isolation: "true"` which requires pods to carry this label for the webhook to mutate them. Since e2e test pods (and user workloads) don't have this label, the webhook silently stopped injecting `runtimeClassName`, causing all Hyper-V CI jobs to run in process isolation since March 2026.

**Fix**: Set `objectSelector: {}` to match all pods, consistent with the HPC webhook pattern in `values-hpc.yaml`.

**Evidence**: On the [serial-slow TestGrid](https://testgrid.k8s.io/sig-windows-master-release#capz-windows-master-hyperv-serial-slow), tests have been silently passing in process isolation. After this fix, we verified via `hcsdiag list` that Hyper-V utility VMs are actually running.

### 2. hostNetwork incompatibility (webhook.go)

Hyper-V containers run inside a utility VM with its own network namespace, which is fundamentally incompatible with `hostNetwork: true`. The Container Runtime blackbox tests use `hostNetwork: true` for their `fake-registry-server` and were failing under Hyper-V isolation.

**Fix**: Skip pods with `pod.Spec.HostNetwork == true` in the webhook (after the existing HostProcess check, before the Linux check). This is safe because:
- HostProcess pods (which use hostNetwork) are already skipped
- The HPC webhook handles hostNetwork + agnhost pods separately
- No conflicts between the two webhooks

### Testing

Ran full e2e tests on a Hyper-V cluster (`davwei-capz-hyperv-202604130444`, Windows Server 2025 + containerd 2.1.6):
- **Serial-slow**: 52 passed, 12 failed (vs 51 passed, 7 failed before fix)
- Verified `hcsdiag list` shows Hyper-V VMs running ✅
- Verified hostNetwork pods are correctly skipped ✅
- 4 Container Runtime failures are now due to Pod Security (runAsNonRoot vs ContainerAdministrator), not Hyper-V

/sig windows
/area hyperv