### PR TITLE
Fix Hyper-V webhook image name in Makefile and remove containerd v2.1.6 pin

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -31,23 +31,6 @@ main() {
     export GMSA="${GMSA:-""}" 
     export HYPERV="${HYPERV:-""}"
 
-    # Pin containerd to v2.1.6 for Hyper-V testing to avoid hcsshim SandboxPlatform
-    # validation bug in containerd >= 2.2.1 (hcsshim >= v0.14.0-rc.1).
-    #
-    # Root cause: containerd's config_windows.go sets SandboxIsolation=1 for the
-    # runhcs-wcow-hypervisor runtime but omits SandboxPlatform, making shim options
-    # non-empty. hcsshim PR #2473 added strict validation that calls
-    # platforms.Parse("") on the empty SandboxPlatform, which fails. containerd
-    # v2.1.6 bundles hcsshim v0.13.0 (pre-dates this validation).
-    #
-    # Upstream references:
-    #   - hcsshim validation: https://github.com/microsoft/hcsshim/pull/2473
-    #   - containerd missing default: https://github.com/containerd/containerd/blob/main/internal/cri/config/config_windows.go
-    if [[ "${HYPERV}" == "true" && ("${WINDOWS_CONTAINERD_URL}" == "latest" || -z "${WINDOWS_CONTAINERD_URL}") ]]; then
-        export WINDOWS_CONTAINERD_URL="https://github.com/containerd/containerd/releases/download/v2.1.6/containerd-2.1.6-windows-amd64.tar.gz"
-        log "HYPERV=true: pinning containerd to v2.1.6 to avoid SandboxPlatform bug"
-    fi
-
     export KPNG="${WINDOWS_KPNG:-""}"
     export CALICO_VERSION="${CALICO_VERSION:-"v3.31.0"}"
     export TEMPLATE="${TEMPLATE:-"windows-ci.yaml"}"

--- a/helpers/Makefile
+++ b/helpers/Makefile
@@ -24,7 +24,7 @@ REGISTRY ?= sigwindowstools
 VERSION ?= latest
 
 # Constructed image names
-HYPERV_IMG = $(REGISTRY)/hyperv-webhook:$(VERSION)
+HYPERV_IMG = $(REGISTRY)/hyperv-runtimeclass-mutating-webhook:$(VERSION)
 HPC_IMG = $(REGISTRY)/hpc-webhook:$(VERSION)
 
 # Go version for building images


### PR DESCRIPTION
## What this PR does

### Fix 1: Webhook image name mismatch in helpers/Makefile

PR #546 (Helm migration) introduced a new `helpers/Makefile` that builds the Hyper-V webhook image as `sigwindowstools/hyperv-webhook`, but `values-hyperv.yaml` still references the original name `sigwindowstools/hyperv-runtimeclass-mutating-webhook`. This means the `webhook-build` GitHub Action pushes to a different image than what the Helm chart deploys, leaving CI using a stale image from 2024-05-16 (built with k8s API v0.26.0).

The old image drops `restartPolicy: Always` from sidecar init containers during JSON round-trip (the field was added in k8s 1.28 / API v0.28.0), causing 30+ `Forbidden: may not be set for init containers` test failures in CI.

**Fix**: Update `helpers/Makefile` to use `hyperv-runtimeclass-mutating-webhook` to match `values-hyperv.yaml` and the original per-webhook Makefile.

### Fix 2: Remove containerd v2.1.6 pin for Hyper-V

The containerd v2.1.6 pin was added to work around an hcsshim SandboxPlatform validation bug in containerd >= 2.2.1. This bug is now fixed in containerd >= 2.2.3 (the current latest release). The CI preset `preset-capz-containerd-2-0-latest` sets `WINDOWS_CONTAINERD_URL=latest`, which will now resolve to v2.2.3+ correctly.

## Testing

- Verified `sigwindowstools/hyperv-runtimeclass-mutating-webhook:latest` on Docker Hub was last updated 2024-05-16
- Confirmed `webhook-build` Action (run #24423450922) pushes via `cd helpers && make docker-push-all` which uses the new Makefile
- Confirmed containerd v2.2.3 resolves the SandboxPlatform bug in local e2e testing

/cc @marosset