### PR TITLE
Pin GitHub Actions to commit SHAs and configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    open-pull-requests-limit: 10
+    # Group action updates together for easier review
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps): "
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/capz.yml
+++ b/.github/workflows/capz.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       # https://github.com/github/super-linter
       - name: Lint Code Base
-        uses: super-linter/super-linter@v6.5.0
+        uses: super-linter/super-linter@56576d491db07c7236b445ab09991ca49d12b0c6 # v6.5.0
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: true
@@ -30,8 +30,8 @@ jobs:
     name: lint go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.22"
           cache: false # workaround for golangci-lint caching issues https://github.com/golangci/golangci-lint-action/pull/704
@@ -42,7 +42,7 @@ jobs:
           go mod tidy
           popd
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: latest
           working-directory: capz/gmsa/configuration
@@ -50,9 +50,9 @@ jobs:
   build-gmsa-configuration:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: "1.22"
     - name: build-gmsa-configuration
@@ -63,7 +63,7 @@ jobs:
   capz-templates:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: generate templates 
       run: |
         cd capz

--- a/.github/workflows/helm-chart-validation.yaml
+++ b/.github/workflows/helm-chart-validation.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         values-file: [values-hpc.yaml, values-hyperv.yaml]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Install Helm
         run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/webhook-build.yaml
+++ b/.github/workflows/webhook-build.yaml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build both webhook images
         if: ${{ github.event_name != 'push' }}


### PR DESCRIPTION
Pin all action references in workflows to immutable commit SHAs (with version tags preserved as comments) to comply with the repository's security policy and mitigate tag-tampering risks. Also add Dependabot configuration to keep the pinned SHAs updated weekly via grouped pull requests.