### PR TITLE
Add Pod Overhead and scheduling to Hyper-V RuntimeClass

### DIFF
--- a/helpers/helm/templates/runtimeclass.yaml
+++ b/helpers/helm/templates/runtimeclass.yaml
@@ -6,4 +6,13 @@ metadata:
   labels:
     {{- include "webhook.labels" . | nindent 4 }}
 handler: {{ .Values.runtimeClass.handler }}
+{{- with .Values.runtimeClass.overhead }}
+overhead:
+  podFixed:
+    {{- toYaml .podFixed | nindent 4 }}
+{{- end }}
+{{- with .Values.runtimeClass.scheduling }}
+scheduling:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/helpers/helm/values-hyperv.yaml
+++ b/helpers/helm/values-hyperv.yaml
@@ -55,15 +55,25 @@ runtimeClass:
   name: runhcs-wcow-hypervisor
   handler: runhcs-wcow-hypervisor
 
-# Hyper-V specific configuration
-hypervConfig:
-  # Default Hyper-V isolation settings
-  runtimeClassName: runhcs-wcow-hypervisor
-  
-  # CPU and memory limits for Hyper-V isolated containers
-  defaultResources:
-    cpuLimit: "1000m"
-    memoryLimit: "2Gi"
-  
-  # Enable automatic resource adjustment
-  autoAdjustResources: true
+  # Pod overhead accounts for the Hyper-V Utility VM (UVM) resource consumption
+  # on the host. Each Hyper-V isolated container runs inside a UVM which consumes
+  # host memory and CPU beyond what the container itself requests. Without this,
+  # the scheduler over-commits nodes and the eviction manager cannot correctly
+  # attribute memory pressure to Hyper-V pods.
+  #
+  # KEP-688: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md
+  # Kubernetes automatically injects these values into pod.spec.overhead when
+  # a pod uses this RuntimeClass (via the built-in RuntimeClass admission controller).
+  overhead:
+    podFixed:
+      memory: "512Mi"
+      cpu: "100m"
+
+  # Scheduling constraints ensure pods using this RuntimeClass are only
+  # scheduled to Windows nodes that support Hyper-V isolation.
+  scheduling:
+    nodeSelector:
+      kubernetes.io/os: windows
+      kubernetes.io/arch: amd64
+
+

--- a/helpers/hyper-v-mutating-webhook/hyperv-runtimeclass.yaml
+++ b/helpers/hyper-v-mutating-webhook/hyperv-runtimeclass.yaml
@@ -3,6 +3,10 @@ kind: RuntimeClass
 metadata:
   name: runhcs-wcow-hypervisor
 handler: runhcs-wcow-hypervisor
+overhead:
+  podFixed:
+    memory: "512Mi"
+    cpu: "100m"
 scheduling:
   nodeSelector:
     kubernetes.io/os: 'windows'


### PR DESCRIPTION
## What this PR does

Configures the `runhcs-wcow-hypervisor` RuntimeClass with Pod Overhead (KEP-688) and scheduling constraints.

### Changes

1. **Pod Overhead**: Adds `overhead.podFixed` (512Mi memory, 100m CPU) to account for Hyper-V Utility VM (UVM) resource consumption on the host. Kubernetes automatically injects these values into `pod.spec.overhead` via the built-in RuntimeClass admission controller.

2. **Scheduling nodeSelector**: Adds `kubernetes.io/os: windows` and `kubernetes.io/arch: amd64` to the Helm-deployed RuntimeClass (was missing from the Helm template, only present in the static YAML).

3. **Remove unused hypervConfig**: The `hypervConfig` section in `values-hyperv.yaml` defined `defaultResources` that were never consumed by the webhook code.

### Why this is needed

Each Hyper-V container runs inside a Utility VM (UVM) that consumes ~200-500MB of host memory beyond what the container requests. Without Pod Overhead:

- **Scheduler over-commits nodes** — packs too many pods, each with hidden UVM overhead
- **Eviction manager mis-ranks pods** — can't attribute UVM memory to the correct pod
- **Serial e2e tests cascade-fail** — memory-intensive tests leave nodes in MemoryPressure because UVM overhead wasn't accounted for, causing 4-5 subsequent tests to fail with "no ready, schedulable nodes"

With Pod Overhead, the scheduler reserves 512Mi per pod for UVM overhead, preventing over-commitment and reducing memory pressure cascades.

### Evidence from CI

The `capz-windows-master-hyperv-serial-slow` job consistently fails with memory pressure cascades:
- Memory Limits test fills node memory → MemoryPressure taint → subsequent tests fail
- Root cause: 16GB node with ~20 Hyper-V pods, each with ~500MB hidden UVM overhead = ~10GB unaccounted

### References

- [KEP-688: Pod Overhead](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md) (GA since k8s 1.24)
- [Pod Overhead documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/)

/cc @jsturtevant @kiashok