### PR TITLE
Skip non-Windows pods in Hyper-V mutating webhook

### DIFF
--- a/helpers/hyper-v-mutating-webhook/webhook.go
+++ b/helpers/hyper-v-mutating-webhook/webhook.go
@@ -67,6 +67,15 @@ func (pu *podUpdater) Handle(ctx context.Context, req admission.Request) admissi
 		mutatePod = false
 	}
 
+	// Don't apply hyper-v runtime class for pods that have custom nodeSelectors
+	// but no kubernetes.io/os selector. These are likely test fixture pods
+	// (e.g., ResourceQuota tests with unsatisfiable selectors) that are not
+	// intended to run as Windows workloads. Injecting overhead into them would
+	// break resource accounting in those tests.
+	if _, hasOS := pod.Spec.NodeSelector["kubernetes.io/os"]; !hasOS && len(pod.Spec.NodeSelector) > 0 {
+		mutatePod = false
+	}
+
 	if mutatePod {
 		podName := pod.Name
 		webhookLogger.Info(fmt.Sprintf("Pod %s is being mutated", podName))


### PR DESCRIPTION
## What this PR does

Fixes the Hyper-V mutating webhook to skip pods that have custom nodeSelectors but no `kubernetes.io/os` selector. These are test fixture pods (e.g., ResourceQuota tests with `x-test.k8s.io/unsatisfiable` selectors) that are not intended to run as Windows workloads.

## Why this is needed

After PR #560 added Pod Overhead (512Mi memory, 100m CPU) to the `runhcs-wcow-hypervisor` RuntimeClass, the webhook injects this RuntimeClass into **all** pods that aren't explicitly Linux, HostProcess, or HostNetwork. This includes test fixture pods that never run on Windows nodes, causing 4 consistent ResourceQuota test failures on `capz-windows-master-hyperv`:

```
pods "test-pod" is forbidden: exceeded quota: test-quota,
  requested: memory=764Mi,     <- 252Mi (pod) + 512Mi (overhead)
  limited: memory=500Mi
```

### How the fix works

| Pod nodeSelector | Before | After |
|---|---|---|
| `{}` (empty, common in e2e tests) | INJECT | INJECT (unchanged) |
| `{kubernetes.io/os: windows}` | INJECT | INJECT (unchanged) |
| `{kubernetes.io/os: linux}` | SKIP | SKIP (unchanged) |
| `{x-test.k8s.io/unsatisfiable: ...}` | INJECT (wrong) | **SKIP** (fixed) |
| `{tier: frontend}` (no OS) | INJECT | **SKIP** (fixed) |

## CI Impact

Fixes 4 consistent failures on [capz-windows-master-hyperv](https://testgrid.k8s.io/sig-windows-signal#capz-windows-master-hyperv):
- ResourceQuota should create a ResourceQuota and capture the life of a pod
- ResourceQuota should verify ResourceQuota with terminating scopes
- ResourceQuota should verify ResourceQuota with terminating scopes through scope selectors
- ResourceQuota priority class scope (cpu, memory quota set)

/cc @jsturtevant @kiashok