### PR TITLE
helpers/helm: skip img-puller namespace in Hyper-V webhook

### DIFF
--- a/helpers/helm/values-hyperv.yaml
+++ b/helpers/helm/values-hyperv.yaml
@@ -49,6 +49,26 @@ webhookConfiguration:
   path: /mutate-v1-pod
   objectSelector: {}
 
+  # Namespace selector. Helm replaces lists wholesale, so include
+  # both the baseline system exclusions and the Hyper-V-specific ones.
+  namespaceSelector:
+    matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+          - kube-system
+          - calico-system
+          - tigera-operator
+      # Skip the e2e suite's img-puller namespace (test/e2e/e2e.go::
+      # prepullImages). Its Linux helper DaemonSets cannot run as
+      # Hyper-V isolated pods. Filtered on the e2e-framework label set
+      # by framework.CreateTestingNS since the namespace name carries a
+      # random suffix.
+      - key: e2e-framework
+        operator: NotIn
+        values:
+          - img-puller
+
 # RuntimeClass configuration for Hyper-V
 runtimeClass:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**

The e2e suite's `img-puller` namespace (created by `test/e2e/e2e.go::prepullImages`) runs DaemonSets that prewarm the Windows test images on every Windows worker. The Hyper-V webhook currently injects `runhcs-wcow-hypervisor` into these puller pods, turning each one into a Hyper-V UVM that holds ~500 MiB of host memory for the entire suite duration — and in practice deadlocks `--prepull-images=true` at `SynchronizedBeforeSuite`.

This PR adds a `namespaceSelector` that excludes namespaces labeled `e2e-framework=img-puller` (the label `framework.CreateTestingNS` sets on that namespace).

**Verification**

Validated on a CAPZ Hyper-V cluster (WS2025, k8s v1.37.0-alpha): a full `hyperv-serial-slow` run with `--prepull-images=true` now completes `SynchronizedBeforeSuite` in 76 s instead of deadlocking, and img-puller pods admit with no `runtimeClassName`.

**Release note**
```release-note
NONE
```