### PR TITLE
Set AZURE_RESOURCE_GROUP to workload cluster resource group for some e2e test scenarios

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -63,6 +63,7 @@ main() {
     install_tools
     prepare_cloud_provider_azure
     create_cluster
+    export_workload_cluster_resource_group
     apply_workload_configuration
     apply_cloud_provider_azure
     wait_for_nodes
@@ -316,6 +317,30 @@ create_cluster(){
     export KUBECONFIG="$workload_kubeconfig_path"
 
     log "create_cluster complete"
+}
+
+export_workload_cluster_resource_group() {
+    local workload_resource_group=""
+
+    workload_resource_group=$(kubectl --kubeconfig "${MANAGEMENT_KUBECONFIG}" get azurecluster "${CLUSTER_NAME}" -n default -o jsonpath='{.spec.resourceGroup}' 2>/dev/null || true)
+    if [[ -z "${workload_resource_group}" ]]; then
+        workload_resource_group="${CLUSTER_NAME}"
+        log "AzureCluster resource group lookup unavailable or empty; falling back to ${workload_resource_group}"
+    else
+        log "discovered workload cluster Azure resource group: ${workload_resource_group}"
+    fi
+
+    if [[ -n "${AZURE_RESOURCE_GROUP:-}" ]]; then
+        if [[ "${AZURE_RESOURCE_GROUP}" == "${workload_resource_group}" ]]; then
+            export AZURE_RESOURCE_GROUP
+            log "AZURE_RESOURCE_GROUP already matches workload cluster resource group; exporting AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}"
+            return
+        fi
+        log "WARNING: AZURE_RESOURCE_GROUP was set to ${AZURE_RESOURCE_GROUP}; exporting workload cluster resource group ${workload_resource_group} for this CAPZ e2e run"
+    fi
+
+    export AZURE_RESOURCE_GROUP="${workload_resource_group}"
+    log "exporting AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}"
 }
 
 wait_for_windows_machinedeployment() {


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/6305

run-capz-e2e.sh did not export AZURE_RESOURCE_GROUP for post-command tests (like azuredisk-csi-driver e2e test) which does get set by CAPZ's ci-entrypoint.sh, so azuredisk e2e generated a credential file using a random fallback resource group. 
This caused direct ControllerPublishVolume calls to look for CAPZ node VMs in the wrong RG and fail with instance not found; the change exports the workload cluster RG from AzureCluster.spec.resourceGroup before running post commands.

/sig windows
/assign @jackfrancis @mboersma @zylxjtu 
/cc @andyzhangx 