### PR TITLE
Set os disk caching for in capz templates

### DIFF
--- a/capz/templates/1.29/windows-ci.yaml
+++ b/capz/templates/1.29/windows-ci.yaml
@@ -436,6 +436,7 @@ spec:
           name: ${GALLERY_IMAGE_NAME:=capi-win-2022-containerd}
           version: ${IMAGE_VERSION:=latest}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/1.29/windows-pr.yaml
+++ b/capz/templates/1.29/windows-pr.yaml
@@ -424,6 +424,7 @@ spec:
           name: ${GALLERY_IMAGE_NAME:=capi-win-2022-containerd}
           version: ${IMAGE_VERSION:=latest}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -618,6 +618,7 @@ spec:
           subscriptionID: ${AZURE_SUBSCRIPTION_ID:=46678f10-4bbb-447e-98e8-d2829589f2d8}
           version: ${IMAGE_VERSION:=latest}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -591,6 +591,7 @@ spec:
           subscriptionID: ${AZURE_SUBSCRIPTION_ID:=46678f10-4bbb-447e-98e8-d2829589f2d8}
           version: ${IMAGE_VERSION:=latest}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -566,6 +566,7 @@ spec:
           subscriptionID: ${AZURE_SUBSCRIPTION_ID}
           version: ${IMAGE_VERSION:=0.3.1707767847}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -458,6 +458,7 @@ spec:
       identity: UserAssigned
       image:
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -615,6 +615,7 @@ spec:
           subscriptionID: ${AZURE_SUBSCRIPTION_ID:=46678f10-4bbb-447e-98e8-d2829589f2d8}
           version: ${IMAGE_VERSION:=latest}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -588,6 +588,7 @@ spec:
           subscriptionID: ${AZURE_SUBSCRIPTION_ID:=46678f10-4bbb-447e-98e8-d2829589f2d8}
           version: ${IMAGE_VERSION:=latest}
       osDisk:
+        cachingType: ReadWrite
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS


### PR DESCRIPTION
I have a suspicion that the frequent OSProvisioning timeouts we see (and attempt to fix as part of run-capz-e2e.sh may be caused by not having caching enabled for the OS disk on Windows.

In CAPZ the default value is none, which may work for linux, but on Windows, the first boot is very disk intensive and delays in reads/writes caused by not having a caching layer could be contributing to some of these timeouts

Example of the timeout as seen in run-capz-e2e.sh logs
```log
RESPONSE 200: 200 OK
ERROR CODE: OSProvisioningClientError
{
"startTime": "2026-05-26T16:38:58.8406405+00:00",
"endTime": "2026-05-26T16:43:18.9291258+00:00",
"status": "Failed",
"error": {
"code": "OSProvisioningClientError",
"message": "OS Provisioning for VM 'capz-conf-297wv' did not finish in the allotted time. However, the VM guest agent was detected running. This suggests the guest OS has not been properly prepared to be used as a VM image (with CreateOption=FromImage). To resolve this issue, either use the VHD as is with CreateOption=Attach or prepare it properly for use as an image:\r\n * Instructions for Windows: [https://learn.microsoft.com/azure/virtual-machines/windows/prepare-for-upload-vhd-image\r\n](vscode-file://vscode-app/c:/Users/marosset/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/sessions/electron-browser/sessions.html) * Instructions for Linux: [https://learn.microsoft.com/azure/virtual-machines/linux/create-upload-generic](vscode-file://vscode-app/c:/Users/marosset/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/sessions/electron-browser/sessions.html) "
},
"name": "97bf1b69-0a3e-4c8e-931c-206ba710ad71"

}
```

/hold for tests
/assign @zylxjtu 