### PR TITLE
capz: add MAX_PODS knob to override kubelet max pods on Windows nodes

### DIFF
--- a/capz/run-capz-e2e.sh
+++ b/capz/run-capz-e2e.sh
@@ -30,6 +30,8 @@ main() {
     export WINDOWS_CONTAINERD_URL="${WINDOWS_CONTAINERD_URL:-"https://github.com/containerd/containerd/releases/download/v1.7.16/containerd-1.7.16-windows-amd64.tar.gz"}"
     export GMSA="${GMSA:-""}" 
     export HYPERV="${HYPERV:-""}"
+    # Override kubelet maxPods (e.g. Hyper-V Prow jobs set MAX_PODS=20).
+    export MAX_PODS="${MAX_PODS:-}"
 
     export KPNG="${WINDOWS_KPNG:-""}"
     export CALICO_VERSION="${CALICO_VERSION:-"v3.31.0"}"

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -155,6 +155,11 @@ spec:
             $content += "shutdownGracePeriod: 1m"
             $content += "shutdownGracePeriodCriticalPods: 20s"
           }
+          # Override kubelet maxPods when MAX_PODS is set (envsubst at apply time).
+          if ("${MAX_PODS}" -ne "") {
+            $content = $content | Where-Object { $_ -notmatch "^maxPods:" }
+            $content += "maxPods: ${MAX_PODS}"
+          }
 
           # Write the updated content back to the file
           $content | Set-Content -Path $configFile -Encoding ascii

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -155,6 +155,11 @@ spec:
             $content += "shutdownGracePeriod: 1m"
             $content += "shutdownGracePeriodCriticalPods: 20s"
           }
+          # Override kubelet maxPods when MAX_PODS is set (envsubst at apply time).
+          if ("${MAX_PODS}" -ne "") {
+            $content = $content | Where-Object { $_ -notmatch "^maxPods:" }
+            $content += "maxPods: ${MAX_PODS}"
+          }
 
           # Write the updated content back to the file
           $content | Set-Content -Path $configFile -Encoding ascii

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -155,6 +155,11 @@ spec:
             $content += "shutdownGracePeriod: 1m"
             $content += "shutdownGracePeriodCriticalPods: 20s"
           }
+          # Override kubelet maxPods when MAX_PODS is set (envsubst at apply time).
+          if ("${MAX_PODS}" -ne "") {
+            $content = $content | Where-Object { $_ -notmatch "^maxPods:" }
+            $content += "maxPods: ${MAX_PODS}"
+          }
 
           # Write the updated content back to the file
           $content | Set-Content -Path $configFile -Encoding ascii

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -155,6 +155,11 @@ spec:
             $content += "shutdownGracePeriod: 1m"
             $content += "shutdownGracePeriodCriticalPods: 20s"
           }
+          # Override kubelet maxPods when MAX_PODS is set (envsubst at apply time).
+          if ("${MAX_PODS}" -ne "") {
+            $content = $content | Where-Object { $_ -notmatch "^maxPods:" }
+            $content += "maxPods: ${MAX_PODS}"
+          }
 
           # Write the updated content back to the file
           $content | Set-Content -Path $configFile -Encoding ascii

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -155,6 +155,11 @@ spec:
             $content += "shutdownGracePeriod: 1m"
             $content += "shutdownGracePeriodCriticalPods: 20s"
           }
+          # Override kubelet maxPods when MAX_PODS is set (envsubst at apply time).
+          if ("${MAX_PODS}" -ne "") {
+            $content = $content | Where-Object { $_ -notmatch "^maxPods:" }
+            $content += "maxPods: ${MAX_PODS}"
+          }
 
           # Write the updated content back to the file
           $content | Set-Content -Path $configFile -Encoding ascii

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -155,6 +155,11 @@ spec:
             $content += "shutdownGracePeriod: 1m"
             $content += "shutdownGracePeriodCriticalPods: 20s"
           }
+          # Override kubelet maxPods when MAX_PODS is set (envsubst at apply time).
+          if ("${MAX_PODS}" -ne "") {
+            $content = $content | Where-Object { $_ -notmatch "^maxPods:" }
+            $content += "maxPods: ${MAX_PODS}"
+          }
 
           # Write the updated content back to the file
           $content | Set-Content -Path $configFile -Encoding ascii


### PR DESCRIPTION
**What this PR does / why we need it**

On Windows-on-Hyper-V worker nodes, every pod that lands on the `runhcs-wcow-hypervisor` RuntimeClass spins up a Hyper-V UVM that consumes ~500 MiB of host *non-paged kernel pool* and substantial HNS state. This overhead is invisible to kubelet's pod-level stats (it lives in `vmmem.exe`/`vmwp.exe`), so the default `--max-pods=110` allows enough pods to exhaust the kernel pool. Once that happens, new pods fail to start with `HCN_E_ADDR_INVALID_OR_RESERVED` (0x803b002f) and HNS returns `0xe`, cascading into MemoryPressure evictions, `SchedulerPreemption` failures, and Calico HNS endpoint cleanup issues. This is what makes the `capz-windows-master-hyperv*` testgrid dashboards flake.

This PR caps `maxPods` at 20 on Windows workers whenever `HYPERV=true` by templating `HYPERV_MAX_PODS` into the kubelet config for the `KubeadmConfigTemplate` of every Windows machine pool, defaulted in `run-capz-e2e.sh`. Set `HYPERV_MAX_PODS=""` to opt out.

**Validation**

Three back-to-back full provision → e2e → cleanup iterations against the upstream `capz-windows-master-hyperv` shape (uksouth, AKS mgmt + CAPZ workload, 1× CP + 2× WS2025 Hyper-V `Standard_D4s_v3` workers, ginkgo `--nodes=4`, focus/skip matching the Prow job verbatim):

| Iter | E2E wall | Tests | Failures | Errors | `0x803b002f` cascades |
|------|----------|-------|----------|--------|-----------------------|
| 1    | 1h04m    | 7600  | **0**    | **0**  | **0** |
| 2    | 1h24m    | 7602  | **0**    | **0**  | **0** |
| 3    | 1h06m    | 7602  | **0**    | **0**  | **0** |

For comparison, recent un-patched runs of the same Prow job have hundreds of `0x803b002f` markers and 1–8 spec failures per run.

**Special notes for your reviewer**

- The cap is opt-out (`HYPERV_MAX_PODS=""` disables injection).
- Touches every Windows-bearing template (`windows-base`, `windows-ci`, `windows-pr`, `gmsa-ci`, `gmsa-pr`, `shared-image-gallery-ci`).
- Process-isolated runs (`HYPERV=false`) are unaffected: the envsubst block expands to empty.

**Release note**

```release-note
NONE
```
