### PR TITLE
Run Windows-specific e2e node tests

### DIFF
--- a/scripts/k8s_e2e_node_windows.ps1
+++ b/scripts/k8s_e2e_node_windows.ps1
@@ -63,7 +63,7 @@ function Run-K8se2enodeWindowsTests {
     }
 
     Write-Host "Running e2e node tests"
-    go test ./test/e2e_node `
+    go test ./test/e2e_node_windows `
         --bearer-token=vQIYfdCt7wIFOZtO `
         --test.v `
         --test.paniconexit0 `

--- a/scripts/prepare_e2e_node_windows.ps1
+++ b/scripts/prepare_e2e_node_windows.ps1
@@ -11,8 +11,12 @@ Stop-Service containerd -ErrorAction Continue
 sc.exe delete containerd -ErrorAction Continue
 
 # Download and extract desired containerd Windows binaries
-curl.exe -LO https://github.com/containerd/containerd/releases/download/v$ContainerdVersion/containerd-$ContainerdVersion-windows-amd64.tar.gz
-tar.exe xvf .\containerd-$ContainerdVersion-windows-amd64.tar.gz
+if ($ContainerdVersion -eq "nightly") {
+    curl.exe -L -o containerd.tar.gz https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/windows-containerd-nightly/windows-containerd.tar.gz
+} else {
+    curl.exe -L -o containerd.tar.gz https://github.com/containerd/containerd/releases/download/v$ContainerdVersion/containerd-$ContainerdVersion-windows-amd64.tar.gz
+}
+tar.exe xvf .\containerd.tar.gz
 
 # Copy
 Copy-Item -Path .\bin -Destination $Env:ProgramFiles\containerd -Recurse -Force


### PR DESCRIPTION
Point the e2e node test runner at ./test/e2e_node_windows instead of the ./test/e2e_node package.

Add the option of "nightly" for containerd version