### PR TITLE
capz: actually restart kubelet in nssm fallback so config.yaml changes apply

### DIFF
--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -177,6 +177,8 @@ spec:
           } else {
               Write-Host "RestartKubelet.ps1 not found. Running fallback command..."
               & "$env:SYSTEMDRIVE\k\nssm.exe" set kubelet start SERVICE_AUTO_START
+              # Actually restart the running kubelet so config.yaml changes take effect.
+              & "$env:SYSTEMDRIVE\k\nssm.exe" restart kubelet
           }
         path: C:/KubeletRestart_nssm_sc.ps1
         permissions: "0744"

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -177,6 +177,8 @@ spec:
           } else {
               Write-Host "RestartKubelet.ps1 not found. Running fallback command..."
               & "$env:SYSTEMDRIVE\k\nssm.exe" set kubelet start SERVICE_AUTO_START
+              # Actually restart the running kubelet so config.yaml changes take effect.
+              & "$env:SYSTEMDRIVE\k\nssm.exe" restart kubelet
           }
         path: C:/KubeletRestart_nssm_sc.ps1
         permissions: "0744"

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -177,6 +177,8 @@ spec:
           } else {
               Write-Host "RestartKubelet.ps1 not found. Running fallback command..."
               & "$env:SYSTEMDRIVE\k\nssm.exe" set kubelet start SERVICE_AUTO_START
+              # Actually restart the running kubelet so config.yaml changes take effect.
+              & "$env:SYSTEMDRIVE\k\nssm.exe" restart kubelet
           }
         path: C:/KubeletRestart_nssm_sc.ps1
         permissions: "0744"

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -178,6 +178,8 @@ spec:
           } else {
               Write-Host "RestartKubelet.ps1 not found. Running fallback command..."
               & "$env:SYSTEMDRIVE\k\nssm.exe" set kubelet start SERVICE_AUTO_START
+              # Actually restart the running kubelet so config.yaml changes take effect.
+              & "$env:SYSTEMDRIVE\k\nssm.exe" restart kubelet
           }
         path: C:/KubeletRestart_nssm_sc.ps1
         permissions: "0744"

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -177,6 +177,8 @@ spec:
           } else {
               Write-Host "RestartKubelet.ps1 not found. Running fallback command..."
               & "$env:SYSTEMDRIVE\k\nssm.exe" set kubelet start SERVICE_AUTO_START
+              # Actually restart the running kubelet so config.yaml changes take effect.
+              & "$env:SYSTEMDRIVE\k\nssm.exe" restart kubelet
           }
         path: C:/KubeletRestart_nssm_sc.ps1
         permissions: "0744"

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -177,6 +177,8 @@ spec:
           } else {
               Write-Host "RestartKubelet.ps1 not found. Running fallback command..."
               & "$env:SYSTEMDRIVE\k\nssm.exe" set kubelet start SERVICE_AUTO_START
+              # Actually restart the running kubelet so config.yaml changes take effect.
+              & "$env:SYSTEMDRIVE\k\nssm.exe" restart kubelet
           }
         path: C:/KubeletRestart_nssm_sc.ps1
         permissions: "0744"


### PR DESCRIPTION
## What this PR does

Fixes the kubelet restart fallback so that `config.yaml` edits made in `postKubeadmCommands` actually take effect.

`KubeletRestart_nssm_sc.ps1` runs after `updateKubeletConfig.ps1` (which can append `maxPods`, `shutdownGracePeriod` and `enableSystemLogQuery` to the kubelet `config.yaml`). When `C:/k/RestartKubelet.ps1` is absent on the node
image, the fallback only ran:

```
nssm set kubelet start SERVICE_AUTO_START
```

That changes the service **start type** but does **not** restart the running kubelet, so the edited `config.yaml` is never reloaded. The node therefore keeps kubelet defaults.

/sig windows
/area provider/azure
