### PR TITLE
Use capzicicommunity register for calico node and add defender excluson for containerd tmpmount

### DIFF
--- a/capz/templates/calico/values.yaml
+++ b/capz/templates/calico/values.yaml
@@ -1,4 +1,5 @@
 installation:
+  registry: capzcicommunity.azurecr.io
   cni:
     type: Calico
   calicoNetwork:

--- a/capz/templates/gmsa-ci.yaml
+++ b/capz/templates/gmsa-ci.yaml
@@ -521,6 +521,9 @@ spec:
     postKubeadmCommands:
     - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
+    - mkdir -p /var/lib/containerd/tmpmounts
+    - timeout 2m bash -c 'until mdatp health >/dev/null 2>&1; do sleep 2; done'
+    - mdatp exclusion folder add --path /var/lib/containerd/tmpmounts --scope global
     - bash -c /tmp/kubeadm-bootstrap.sh
     - bash -c /tmp/oot-cred-provider.sh
     useExperimentalRetryJoin: true

--- a/capz/templates/gmsa-pr.yaml
+++ b/capz/templates/gmsa-pr.yaml
@@ -494,6 +494,9 @@ spec:
     postKubeadmCommands:
     - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
+    - mkdir -p /var/lib/containerd/tmpmounts
+    - timeout 2m bash -c 'until mdatp health >/dev/null 2>&1; do sleep 2; done'
+    - mdatp exclusion folder add --path /var/lib/containerd/tmpmounts --scope global
     - bash -c /tmp/replace-k8s-binaries.sh
     - bash -c /tmp/oot-cred-provider.sh
     useExperimentalRetryJoin: true

--- a/capz/templates/shared-image-gallery-ci.yaml
+++ b/capz/templates/shared-image-gallery-ci.yaml
@@ -473,6 +473,9 @@ spec:
     postKubeadmCommands:
     - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
+    - mkdir -p /var/lib/containerd/tmpmounts
+    - timeout 2m bash -c 'until mdatp health >/dev/null 2>&1; do sleep 2; done'
+    - mdatp exclusion folder add --path /var/lib/containerd/tmpmounts --scope global
     - bash -c /tmp/kubeadm-bootstrap.sh
     useExperimentalRetryJoin: true
   machineTemplate:

--- a/capz/templates/windows-base.yaml
+++ b/capz/templates/windows-base.yaml
@@ -371,7 +371,10 @@ spec:
       - /var/lib/etcddisk
     postKubeadmCommands:
     - bash -c /tmp/node-log-query-kubelet-config.sh
-    preKubeadmCommands: []
+    preKubeadmCommands:
+    - mkdir -p /var/lib/containerd/tmpmounts
+    - timeout 2m bash -c 'until mdatp health >/dev/null 2>&1; do sleep 2; done'
+    - mdatp exclusion folder add --path /var/lib/containerd/tmpmounts --scope global
     useExperimentalRetryJoin: true
   machineTemplate:
     infrastructureRef:

--- a/capz/templates/windows-ci.yaml
+++ b/capz/templates/windows-ci.yaml
@@ -521,6 +521,9 @@ spec:
     postKubeadmCommands:
     - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
+    - mkdir -p /var/lib/containerd/tmpmounts
+    - timeout 2m bash -c 'until mdatp health >/dev/null 2>&1; do sleep 2; done'
+    - mdatp exclusion folder add --path /var/lib/containerd/tmpmounts --scope global
     - bash -c /tmp/kubeadm-bootstrap.sh
     - bash -c /tmp/oot-cred-provider.sh
     useExperimentalRetryJoin: true

--- a/capz/templates/windows-pr.yaml
+++ b/capz/templates/windows-pr.yaml
@@ -494,6 +494,9 @@ spec:
     postKubeadmCommands:
     - bash -c /tmp/node-log-query-kubelet-config.sh
     preKubeadmCommands:
+    - mkdir -p /var/lib/containerd/tmpmounts
+    - timeout 2m bash -c 'until mdatp health >/dev/null 2>&1; do sleep 2; done'
+    - mdatp exclusion folder add --path /var/lib/containerd/tmpmounts --scope global
     - bash -c /tmp/replace-k8s-binaries.sh
     - bash -c /tmp/oot-cred-provider.sh
     useExperimentalRetryJoin: true


### PR DESCRIPTION
This should fix the issues being see in https://testgrid.k8s.io/sig-release-master-informing#capz-windows-master&exclude-non-failed-tests= and https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-capz-master-windows/2090774807804121088

I think the actual issue is the calico node image not mounting in sufficient time due to defender scanning but we should use the czapzicommunity pull-through azure container registery for all images coming form quay.io anyways for reliability